### PR TITLE
Fix: Mapsprite import assumed ids were prefixed with '$'. Now handles…

### DIFF
--- a/src/com/sfc/sf2/battle/io/DisassemblyManager.java
+++ b/src/com/sfc/sf2/battle/io/DisassemblyManager.java
@@ -219,7 +219,17 @@ public class DisassemblyManager {
                         while(!line.startsWith("; enum")){
                             if(line.startsWith("MAPSPRITE")){
                                 String key = line.substring(0,line.indexOf(":"));
-                                Integer value = Integer.valueOf(line.substring(line.indexOf("$")+1).trim(), 16);
+                                Integer value = line.indexOf("$")+1;
+                                if (value <= 0){
+                                    value = line.indexOf("equ")+4;
+                                }
+                                Integer comment = line.indexOf(";");
+                                if (comment == -1){
+                                    value = Integer.valueOf(line.substring(value).trim(), 16);
+                                }
+                                else{
+                                    value = Integer.valueOf(line.substring(value, comment).trim(), 16);
+                                }
                                 mapspriteEnum.put(key, value);
                             }
                             line = enumScan.nextLine();


### PR DESCRIPTION
… with or without "$".

Handles the case where MapSprites in SF2ENUMS.asm values are not prefixed by "$".
Did not remove the "$" case.