### PR TITLE
Fix editor to support asm spritesets

### DIFF
--- a/src/com/sfc/sf2/battle/BattleManager.java
+++ b/src/com/sfc/sf2/battle/BattleManager.java
@@ -39,7 +39,7 @@ public class BattleManager {
     private EnemyData[] enemyData = null;
     private EnemyEnums enemyEnums = null;
     
-    public void importDisassembly(String mapPalettesPath, String mapTilesetsPath, String incbinPath, String mapEntriesPath, String mapCoordsPath, String basePalettePath, String mapspriteEntriesPath, String mapspriteEnumPath, String enemySpritesPath,
+    public void importDisassembly(String mapPalettesPath, String mapTilesetsPath, String incbinPath, String mapEntriesPath, String mapCoordsPath, String basePalettePath, String mapspriteEntriesPath, String mapspriteEnumPath,
                                     int battleIndex, String terrainPath, String spritesetPath){
         System.out.println("com.sfc.sf2.battle.BattleManager.importDisassembly() - Importing disassembly ...");
         mapCoordsManager.importDisassembly(mapCoordsPath);
@@ -52,7 +52,7 @@ public class BattleManager {
         mapEntries = importMapEntryFile(incbinPath, mapEntriesPath);
         MapSprite[] mapsprites = mapspriteManager.importDisassemblyFromEntryFile(basePalettePath, mapspriteEntriesPath, incbinPath);
         enemyEnums = DisassemblyManager.importEnemyEnums(mapspriteEnumPath);
-        enemyData = DisassemblyManager.importEnemyData(mapspriteEnumPath, enemySpritesPath, mapsprites);
+        enemyData = DisassemblyManager.importEnemyData(enemyEnums, mapsprites, mapspriteEnumPath);
         battle.setSpriteset(DisassemblyManager.importSpriteset(spritesetPath, enemyData, enemyEnums));
         System.out.println("com.sfc.sf2.battle.BattleManager.importDisassembly() - Disassembly imported.");
     }

--- a/src/com/sfc/sf2/battle/BattleManager.java
+++ b/src/com/sfc/sf2/battle/BattleManager.java
@@ -63,7 +63,7 @@ public class BattleManager {
         mapCoordsManager.exportDisassembly(coordsArray, mapcoordsPath);
         mapTerrainManager.setTerrain(battle.getTerrain());
         mapTerrainManager.exportDisassembly(terrainPath);
-        DisassemblyManager.exportSpriteSet(battle.getSpriteset(), spritesetPath);
+        DisassemblyManager.exportSpriteSet(battle.getSpriteset(), spritesetPath, enemyEnums);
         System.out.println("com.sfc.sf2.battle.BattleManager.importDisassembly() - Disassembly exported.");        
     }      
     

--- a/src/com/sfc/sf2/battle/BattleManager.java
+++ b/src/com/sfc/sf2/battle/BattleManager.java
@@ -35,8 +35,7 @@ public class BattleManager {
     private Battle battle;
     private String[][] mapEntries = null;
     private BattleMapCoords[] coordsArray = null;
-    private MapSprite[] mapsprites = null;
-    private byte[] enemySpriteIds = null;
+    private EnemyData[] enemyData = null;
     
     public void importDisassembly(String mapPalettesPath, String mapTilesetsPath, String incbinPath, String mapEntriesPath, String mapCoordsPath, String basePalettePath, String mapspriteEntriesPath, String mapspriteEnumPath, String enemySpritesPath,
                                     int battleIndex, String terrainPath, String spritesetPath){
@@ -48,10 +47,10 @@ public class BattleManager {
         battle.setMapCoords(coordsArray[battleIndex]);
         mapTerrainManager.importDisassembly(terrainPath);
         battle.setTerrain(mapTerrainManager.getTerrain());
-        battle.setSpriteset(DisassemblyManager.importSpriteset(spritesetPath));
         mapEntries = importMapEntryFile(incbinPath, mapEntriesPath);
-        mapsprites = mapspriteManager.importDisassemblyFromEntryFile(basePalettePath, mapspriteEntriesPath, incbinPath);
-        enemySpriteIds = DisassemblyManager.importEnemySriteIDs(mapspriteEnumPath, enemySpritesPath);
+        MapSprite[] mapsprites = mapspriteManager.importDisassemblyFromEntryFile(basePalettePath, mapspriteEntriesPath, incbinPath);
+        enemyData = DisassemblyManager.importEnemyData(mapspriteEnumPath, enemySpritesPath, mapsprites);
+        battle.setSpriteset(DisassemblyManager.importSpriteset(spritesetPath, enemyData));
         System.out.println("com.sfc.sf2.battle.BattleManager.importDisassembly() - Disassembly imported.");
     }
     
@@ -170,22 +169,11 @@ public class BattleManager {
         this.battle = battle;
     }
 
-    public MapSprite[] getMapsprites() {
-        return mapsprites;
+    public EnemyData[] getEnemyData() {
+        return enemyData;
     }
 
-    public void setMapsprites(MapSprite[] mapsprites) {
-        this.mapsprites = mapsprites;
-    }
-
-    public byte[] getEnemySpriteIds() {
-        return enemySpriteIds;
-    }
-
-    public void setEnemySpriteIds(byte[] enemySpriteIds) {
-        this.enemySpriteIds = enemySpriteIds;
-    }
-    
-    
-    
+    public void setEnemyData(EnemyData[] enemyData) {
+        this.enemyData = enemyData;
+    }    
 }

--- a/src/com/sfc/sf2/battle/BattleManager.java
+++ b/src/com/sfc/sf2/battle/BattleManager.java
@@ -174,9 +174,9 @@ public class BattleManager {
 
     public EnemyData[] getEnemyData() {
         return enemyData;
-    }
-
-    public void setEnemyData(EnemyData[] enemyData) {
-        this.enemyData = enemyData;
     }    
+
+    public EnemyEnums getEnemyEnums() {
+        return enemyEnums;
+    }
 }

--- a/src/com/sfc/sf2/battle/BattleManager.java
+++ b/src/com/sfc/sf2/battle/BattleManager.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,6 +37,7 @@ public class BattleManager {
     private String[][] mapEntries = null;
     private BattleMapCoords[] coordsArray = null;
     private EnemyData[] enemyData = null;
+    private EnemyEnums enemyEnums = null;
     
     public void importDisassembly(String mapPalettesPath, String mapTilesetsPath, String incbinPath, String mapEntriesPath, String mapCoordsPath, String basePalettePath, String mapspriteEntriesPath, String mapspriteEnumPath, String enemySpritesPath,
                                     int battleIndex, String terrainPath, String spritesetPath){
@@ -49,8 +51,9 @@ public class BattleManager {
         battle.setTerrain(mapTerrainManager.getTerrain());
         mapEntries = importMapEntryFile(incbinPath, mapEntriesPath);
         MapSprite[] mapsprites = mapspriteManager.importDisassemblyFromEntryFile(basePalettePath, mapspriteEntriesPath, incbinPath);
+        enemyEnums = DisassemblyManager.importEnemyEnums(mapspriteEnumPath);
         enemyData = DisassemblyManager.importEnemyData(mapspriteEnumPath, enemySpritesPath, mapsprites);
-        battle.setSpriteset(DisassemblyManager.importSpriteset(spritesetPath, enemyData));
+        battle.setSpriteset(DisassemblyManager.importSpriteset(spritesetPath, enemyData, enemyEnums));
         System.out.println("com.sfc.sf2.battle.BattleManager.importDisassembly() - Disassembly imported.");
     }
     

--- a/src/com/sfc/sf2/battle/Enemy.java
+++ b/src/com/sfc/sf2/battle/Enemy.java
@@ -5,22 +5,26 @@
  */
 package com.sfc.sf2.battle;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  *
  * @author wiz
  */
 public class Enemy {
+        
     private EnemyData data;
     private int x;
     private int y;
-    private int ai;
-    private int item;
-    private int moveOrder1;
-    private int triggerRegion;
-    private int byte8;
-    private int byte9;
+    private String ai;
+    private String item;
+    private String moveOrder1;
+    private int triggerRegion1;
+    private String moveOrder2;
+    private int triggerRegion2;
     private int byte10;
-    private int spawnParams;
+    private String spawnParams;
 
     public EnemyData getEnemyData() {
         return data;
@@ -46,52 +50,52 @@ public class Enemy {
         this.y = y;
     }
 
-    public int getAi() {
+    public String getAi() {
         return ai;
     }
 
-    public void setAi(int ai) {
+    public void setAi(String ai) {
         this.ai = ai;
     }
 
-    public int getItem() {
+    public String getItem() {
         return item;
     }
 
-    public void setItem(int item) {
+    public void setItem(String item) {
         this.item = item;
     }
 
-    public int getMoveOrder1() {
+    public String getMoveOrder1() {
         return moveOrder1;
     }
 
-    public void setMoveOrder1(int moveOrder1) {
+    public void setMoveOrder1(String moveOrder1) {
         this.moveOrder1 = moveOrder1;
     }
 
-    public int getTriggerRegion() {
-        return triggerRegion;
+    public int getTriggerRegion1() {
+        return triggerRegion1;
     }
 
-    public void setTriggerRegion(int triggerRegion) {
-        this.triggerRegion = triggerRegion;
+    public void setTriggerRegion1(int triggerRegion1) {
+        this.triggerRegion1 = triggerRegion1;
     }
 
-    public int getByte8() {
-        return byte8;
+    public String getMoveOrder2() {
+        return moveOrder2;
     }
 
-    public void setByte8(int byte8) {
-        this.byte8 = byte8;
+    public void setMoveOrder2(String moveOrder2) {
+        this.moveOrder2 = moveOrder2;
     }
 
-    public int getByte9() {
-        return byte9;
+    public int getTriggerRegion2() {
+        return triggerRegion2;
     }
 
-    public void setByte9(int byte9) {
-        this.byte9 = byte9;
+    public void setTriggerRegion2(int triggerRegion2) {
+        this.triggerRegion2 = triggerRegion2;
     }
 
     public int getByte10() {
@@ -102,13 +106,11 @@ public class Enemy {
         this.byte10 = byte10;
     }
 
-    public int getSpawnParams() {
+    public String getSpawnParams() {
         return spawnParams;
     }
 
-    public void setSpawnParams(int spawnParams) {
+    public void setSpawnParams(String spawnParams) {
         this.spawnParams = spawnParams;
     }
-    
-    
 }

--- a/src/com/sfc/sf2/battle/Enemy.java
+++ b/src/com/sfc/sf2/battle/Enemy.java
@@ -10,7 +10,7 @@ package com.sfc.sf2.battle;
  * @author wiz
  */
 public class Enemy {
-    private int index;
+    private EnemyData data;
     private int x;
     private int y;
     private int ai;
@@ -22,12 +22,12 @@ public class Enemy {
     private int byte10;
     private int spawnParams;
 
-    public int getIndex() {
-        return index;
+    public EnemyData getEnemyData() {
+        return data;
     }
 
-    public void setIndex(int index) {
-        this.index = index;
+    public void setEnemyData(EnemyData data) {
+        this.data = data;
     }
 
     public int getX() {

--- a/src/com/sfc/sf2/battle/EnemyData.java
+++ b/src/com/sfc/sf2/battle/EnemyData.java
@@ -1,0 +1,42 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.sfc.sf2.battle;
+
+import com.sfc.sf2.mapsprite.MapSprite;
+
+/**
+ *
+ * @author TiMMy
+ */
+public class EnemyData {
+    private String name;
+    private int id;
+    private MapSprite mapSprite;
+        
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getID() {
+        return id;
+    }
+
+    public void setID(int id) {
+        this.id = id;
+    }
+
+    public MapSprite getMapSprite() {
+        return mapSprite;
+    }
+
+    public void setMapSprite(MapSprite mapSprite) {
+        this.mapSprite = mapSprite;
+    }
+}

--- a/src/com/sfc/sf2/battle/EnemyEnums.java
+++ b/src/com/sfc/sf2/battle/EnemyEnums.java
@@ -1,0 +1,218 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.sfc.sf2.battle;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ * @author TiMMy
+ */
+public class EnemyEnums {
+    
+    private Map<String, Integer> items;
+    private Map<String, Integer> aiCommandSets;
+    private Map<String, Integer> aiOrders;
+    private Map<String, Integer> spawnParams;
+
+    public Map<String, Integer> getItems() {
+        return items;
+    }
+
+    public void setItems(Map<String, Integer> items) {
+        this.items = items;
+    }
+
+    public Map<String, Integer> getCommandSets() {
+        return aiCommandSets;
+    }
+
+    public void setCommandSets(Map<String, Integer> aiCommandSets) {
+        this.aiCommandSets = aiCommandSets;
+    }
+
+    public Map<String, Integer> getOrders() {
+        return aiOrders;
+    }
+
+    public void setOrders(Map<String, Integer> aiOrders) {
+        this.aiOrders = aiOrders;
+    }
+
+    public Map<String, Integer> getSpawnParams() {
+        return spawnParams;
+    }
+
+    public void setSpawnParams(Map<String, Integer> spawnParams) {
+        this.spawnParams = spawnParams;
+    }
+    
+    //Helper functions
+    
+    public static String toEnumString(String data, Map<String, Integer> en) {
+        try{
+            short number = Short.parseShort(data);
+            return toEnumString(number, en);
+        }
+        catch (NumberFormatException ex){
+            //Not a number
+            return data;
+        }
+    }
+    
+    public static String toEnumString(byte data, Map<String, Integer> en) {
+        return toEnumString((short)data, en);
+    }
+    
+    public static String toEnumString(short data, Map<String, Integer> en) {
+        int number = (int)data;
+        for (Map.Entry<String, Integer> entry : en.entrySet()) {
+            if (number == entry.getValue())
+                return entry.getKey();
+        }
+
+        return String.valueOf(data);    //Fallback
+    }
+    
+    public static byte toEnumByte(String data, Map<String, Integer> en) {
+        return (byte)(toEnumShort(data, en)&0xFF);
+    }
+    
+    public static short toEnumShort(String data, Map<String, Integer> en) {
+        try{
+            short number = Short.parseShort(data);
+            return number;
+        }
+        catch (NumberFormatException ex){
+            //Not a number
+        }
+        
+        String[] split = data.split("|");
+        short value = 0;
+        for (int i = 0; i < split.length; i++) {
+            if (en.containsKey(split[i]))
+                value = (short)(en.get(split[i])&0xFFFF);
+        }
+        
+        return value;
+    }
+    
+    public static String stringToItemString(String data, Map<String, Integer> items) {
+        try{
+            short number = Short.parseShort(data);
+            return itemNumToString(number, items);
+        }
+        catch (NumberFormatException ex){
+            //Not a number
+            return toEnumString(data, items);
+        }
+    }
+    
+    public static String itemNumToString(short data, Map<String, Integer> items) {
+        String s = "";
+        
+        if (data >= 0x1000){  //If flags
+            for (Map.Entry<String, Integer> entry : items.entrySet()) {
+                if ((data&entry.getValue()) != 0){
+                    s = appendItem(s, entry.getKey());
+                    data = (short)(data&(~entry.getValue()));
+                }
+            }
+
+            for (Map.Entry<String, Integer> entry : items.entrySet()) {
+                if ((data == entry.getValue())){
+                    s = prependItem(s, entry.getKey());
+                    return s;
+                }
+            }
+        }
+
+        return Short.toString(data);    //Fallback
+    }
+    
+    public static short itemStringToNum(String data, Map<String, Integer> items) {
+        String[] split = data.split("|");
+                
+        short value = 0;
+        for (int i = 0; i < split.length; i++) {
+            split[i] = split[i].trim();
+            
+            if (items.containsKey(split[i])) {
+                    value += items.get(split[i]);
+            }
+        }
+        
+        return value;
+    }
+    
+    public static String stringToAiOrderString(String data, Map<String, Integer> orders) {
+        try{
+            byte number = Byte.parseByte(data);
+            return aiOrderNumToString(number, orders);
+        }
+        catch (NumberFormatException ex){
+            //Not a number
+            return toEnumString(data, orders);
+        }
+    }
+    
+    public static String aiOrderNumToString(byte data, Map<String, Integer> orders) {        
+        byte value1;
+        byte value2;
+        
+        if (data == 0xFF){
+            value1 = data;
+            value2 = 0;
+        }
+        else{
+            value1 = (byte)(data&0xF0);
+            value2 = (byte)(data&0x0F);
+        }
+        
+        String s = Byte.toString(value2);
+        for (Map.Entry<String, Integer> entry : orders.entrySet()) {
+            if ((value1 == entry.getValue())){
+                s = prependItem(s, entry.getKey());
+                return s;
+            }
+        }
+        
+        return Byte.toString(data); //Fallback
+    }
+    
+    public static byte aiOrderStringToNum(String data, Map<String, Integer> orders) {
+        String[] split = data.split("|");
+        if (split.length < 2)
+            return toEnumByte(split[0], orders);
+        
+        byte value = (byte)(Byte.valueOf(split[1])&0x0F);
+        if (orders.containsKey(split[0])){
+            if (orders.get(split[0]) == 0xFF)
+                value = (byte)0xFF;
+            else
+                value += (byte)(orders.get(split[0])&0xF0);
+        }
+        
+        return value;
+    }
+    
+    private static String appendItem(String current, String append)
+    {
+        if (current.length() == 0)
+            return append;
+        else
+            return current+"|"+append;
+    }
+    
+    private static String prependItem(String current, String prepend)
+    {
+        if (current.length() == 0)
+            return prepend;
+        else
+            return prepend+"|"+current;
+    }
+}

--- a/src/com/sfc/sf2/battle/EnemyEnums.java
+++ b/src/com/sfc/sf2/battle/EnemyEnums.java
@@ -5,7 +5,7 @@
  */
 package com.sfc.sf2.battle;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -13,50 +13,50 @@ import java.util.Map;
  * @author TiMMy
  */
 public class EnemyEnums {
-    
-    private Map<String, Integer> enemies;
-    private Map<String, Integer> items;
-    private Map<String, Integer> aiCommandSets;
-    private Map<String, Integer> aiOrders;
-    private Map<String, Integer> spawnParams;
+        
+    private LinkedHashMap<String, Integer> enemies;
+    private LinkedHashMap<String, Integer> items;
+    private LinkedHashMap<String, Integer> aiCommandSets;
+    private LinkedHashMap<String, Integer> aiOrders;
+    private LinkedHashMap<String, Integer> spawnParams;
 
-    public Map<String, Integer> getEnemies() {
+    public LinkedHashMap<String, Integer> getEnemies() {
         return enemies;
     }
 
-    public void setEemies(Map<String, Integer> enemies) {
+    public void setEemies(LinkedHashMap<String, Integer> enemies) {
         this.enemies = enemies;
     }
 
-    public Map<String, Integer> getItems() {
+    public LinkedHashMap<String, Integer> getItems() {
         return items;
     }
 
-    public void setItems(Map<String, Integer> items) {
+    public void setItems(LinkedHashMap<String, Integer> items) {
         this.items = items;
     }
 
-    public Map<String, Integer> getCommandSets() {
+    public LinkedHashMap<String, Integer> getCommandSets() {
         return aiCommandSets;
     }
 
-    public void setCommandSets(Map<String, Integer> aiCommandSets) {
+    public void setCommandSets(LinkedHashMap<String, Integer> aiCommandSets) {
         this.aiCommandSets = aiCommandSets;
     }
 
-    public Map<String, Integer> getOrders() {
+    public LinkedHashMap<String, Integer> getOrders() {
         return aiOrders;
     }
 
-    public void setOrders(Map<String, Integer> aiOrders) {
+    public void setOrders(LinkedHashMap<String, Integer> aiOrders) {
         this.aiOrders = aiOrders;
     }
 
-    public Map<String, Integer> getSpawnParams() {
+    public LinkedHashMap<String, Integer> getSpawnParams() {
         return spawnParams;
     }
 
-    public void setSpawnParams(Map<String, Integer> spawnParams) {
+    public void setSpawnParams(LinkedHashMap<String, Integer> spawnParams) {
         this.spawnParams = spawnParams;
     }
     

--- a/src/com/sfc/sf2/battle/EnemyEnums.java
+++ b/src/com/sfc/sf2/battle/EnemyEnums.java
@@ -14,10 +14,19 @@ import java.util.Map;
  */
 public class EnemyEnums {
     
+    private Map<String, Integer> enemies;
     private Map<String, Integer> items;
     private Map<String, Integer> aiCommandSets;
     private Map<String, Integer> aiOrders;
     private Map<String, Integer> spawnParams;
+
+    public Map<String, Integer> getEnemies() {
+        return enemies;
+    }
+
+    public void setEemies(Map<String, Integer> enemies) {
+        this.enemies = enemies;
+    }
 
     public Map<String, Integer> getItems() {
         return items;
@@ -91,7 +100,7 @@ public class EnemyEnums {
             //Not a number
         }
         
-        String[] split = data.split("|");
+        String[] split = data.split("\\|");
         short value = 0;
         for (int i = 0; i < split.length; i++) {
             if (en.containsKey(split[i]))
@@ -117,17 +126,17 @@ public class EnemyEnums {
         
         if (data >= 0x1000){  //If flags
             for (Map.Entry<String, Integer> entry : items.entrySet()) {
-                if ((data&entry.getValue()) != 0){
+                if (entry.getValue() > 0x1000 && (data&entry.getValue()) != 0){
                     s = appendItem(s, entry.getKey());
                     data = (short)(data&(~entry.getValue()));
                 }
             }
+        }
 
-            for (Map.Entry<String, Integer> entry : items.entrySet()) {
-                if ((data == entry.getValue())){
-                    s = prependItem(s, entry.getKey());
-                    return s;
-                }
+        for (Map.Entry<String, Integer> entry : items.entrySet()) {
+            if ((data == entry.getValue())){
+                s = prependItem(s, entry.getKey());
+                return s;
             }
         }
 
@@ -135,7 +144,7 @@ public class EnemyEnums {
     }
     
     public static short itemStringToNum(String data, Map<String, Integer> items) {
-        String[] split = data.split("|");
+        String[] split = data.split("\\|");
                 
         short value = 0;
         for (int i = 0; i < split.length; i++) {
@@ -185,7 +194,7 @@ public class EnemyEnums {
     }
     
     public static byte aiOrderStringToNum(String data, Map<String, Integer> orders) {
-        String[] split = data.split("|");
+        String[] split = data.split("\\|");
         if (split.length < 2)
             return toEnumByte(split[0], orders);
         

--- a/src/com/sfc/sf2/battle/gui/BattlePanel.java
+++ b/src/com/sfc/sf2/battle/gui/BattlePanel.java
@@ -295,8 +295,9 @@ public class BattlePanel extends JPanel implements MouseListener, MouseMotionLis
                 Ally ally = allies[i];
                 Font font = new Font("Courier", Font.BOLD, 16);
                 g2.setFont(font);
-                int targetX = (x+ally.getX())*3*8+16-8;
-                int targetY = (y+ally.getY())*3*8+16;
+                int offset = ally.getIndex()+1 < 10 ? 0 : -4;
+                int targetX = (x+ally.getX())*3*8+6+offset;
+                int targetY = (y+ally.getY())*3*8+18;
                 String val = String.valueOf(ally.getIndex()+1);
                 g2.setColor(Color.black);
                 g2.drawString(val, targetX-1, targetY-1);
@@ -318,6 +319,7 @@ public class BattlePanel extends JPanel implements MouseListener, MouseMotionLis
                 int targetY = (y+enemy.getY())*3*8;                
                 int spriteId = (enemySpriteIds[enemy.getIndex()]&0xFF);
                 if(spriteId*3>(mapsprites.length)){
+                    targetX += enemy.getIndex()+1 < 10 ? 0 : -4;
                     g2.setColor(Color.black);
                     g2.drawString(String.valueOf(spriteId), targetX-1, targetY+16-1);
                     g2.drawString(String.valueOf(spriteId), targetX-1, targetY+16+1);

--- a/src/com/sfc/sf2/battle/gui/BattlePanel.java
+++ b/src/com/sfc/sf2/battle/gui/BattlePanel.java
@@ -10,6 +10,7 @@ import com.sfc.sf2.battle.AIRegion;
 import com.sfc.sf2.battle.Ally;
 import com.sfc.sf2.battle.Battle;
 import com.sfc.sf2.battle.Enemy;
+import com.sfc.sf2.battle.EnemyData;
 import com.sfc.sf2.map.block.MapBlock;
 import com.sfc.sf2.map.block.gui.BlockSlotPanel;
 import com.sfc.sf2.map.block.layout.MapBlockLayout;
@@ -83,8 +84,6 @@ public class BattlePanel extends JPanel implements MouseListener, MouseMotionLis
     private Battle battle;
     private MapLayout layout;
     private MapBlock[] blockset;
-    private MapSprite[] mapsprites;
-    private byte[] enemySpriteIds;
     private int currentDisplaySize = 1;
     
     private int applicableTerrainValue = -1;
@@ -315,21 +314,22 @@ public class BattlePanel extends JPanel implements MouseListener, MouseMotionLis
             for(int i=0;i<enemies.length;i++){
                 Enemy enemy = enemies[i];
                 int targetX = (x+enemy.getX())*3*8;
-                int targetY = (y+enemy.getY())*3*8;                
-                int spriteId = (enemySpriteIds[enemy.getIndex()]&0xFF);
-                if(spriteId*3>(mapsprites.length)){
+                int targetY = (y+enemy.getY())*3*8;
+                int id = enemy.getEnemyData().getID();
+                MapSprite sprite = enemy.getEnemyData().getMapSprite();
+                if(sprite == null){
                     g2.setColor(Color.black);
-                    g2.drawString(String.valueOf(spriteId), targetX-1, targetY+16-1);
-                    g2.drawString(String.valueOf(spriteId), targetX-1, targetY+16+1);
-                    g2.drawString(String.valueOf(spriteId), targetX+1, targetY+16-1);
-                    g2.drawString(String.valueOf(spriteId), targetX+1, targetY+16+1);
+                    g2.drawString(String.valueOf(id), targetX-1, targetY+16-1);
+                    g2.drawString(String.valueOf(id), targetX-1, targetY+16+1);
+                    g2.drawString(String.valueOf(id), targetX+1, targetY+16-1);
+                    g2.drawString(String.valueOf(id), targetX+1, targetY+16+1);
                     g2.setColor(Color.RED);
-                    g2.drawString(String.valueOf(spriteId), targetX, targetY+16);  
+                    g2.drawString(String.valueOf(id), targetX, targetY+16);
                 }else{
-                    if(mapspriteImages[spriteId]==null){
-                        mapspriteImages[spriteId] = MapSpriteLayout.buildImage(mapsprites[spriteId*3+2].getTiles(), 6).getSubimage(0, 0, 3*8, 3*8);
+                    if(mapspriteImages[id] == null){
+                        mapspriteImages[id] = MapSpriteLayout.buildImage(sprite.getTiles(), 6).getSubimage(0, 0, 3*8, 3*8);
                     }
-                    g2.drawImage(mapspriteImages[spriteId], targetX, targetY, null); 
+                    g2.drawImage(mapspriteImages[id], targetX, targetY, null);
                 } 
                 if(currentMode==MODE_SPRITE && currentSpritesetMode==SPRITESETMODE_ENEMY && i==selectedEnemy){
                     g2.setColor(Color.YELLOW);
@@ -769,22 +769,6 @@ public class BattlePanel extends JPanel implements MouseListener, MouseMotionLis
     public void updateAIPointDisplay(){
         aiPointsImage = null;
         this.redraw = true;
-    }
-
-    public MapSprite[] getMapsprites() {
-        return mapsprites;
-    }
-
-    public void setMapsprites(MapSprite[] mapsprites) {
-        this.mapsprites = mapsprites;
-    }
-
-    public byte[] getEnemySpriteIds() {
-        return enemySpriteIds;
-    }
-
-    public void setEnemySpriteIds(byte[] enemySpriteIds) {
-        this.enemySpriteIds = enemySpriteIds;
     }
 
     public int getSelectedAlly() {

--- a/src/com/sfc/sf2/battle/gui/BattlePanel.java
+++ b/src/com/sfc/sf2/battle/gui/BattlePanel.java
@@ -299,8 +299,8 @@ public class BattlePanel extends JPanel implements MouseListener, MouseMotionLis
                 Ally ally = allies[i];
                 Font font = new Font("Courier", Font.BOLD, 16);
                 g2.setFont(font);
-                int offset = ally.getIndex()+1 < 10 ? 0 : -4;
-                int targetX = (x+ally.getX())*3*8+6+offset;
+                int offset = (ally.getIndex()+1 < 10) ? 0 : -4;
+                int targetX = (x+ally.getX())*3*8+8+offset;
                 int targetY = (y+ally.getY())*3*8+18;
                 String val = String.valueOf(ally.getIndex()+1);
                 g2.setColor(Color.black);
@@ -324,7 +324,8 @@ public class BattlePanel extends JPanel implements MouseListener, MouseMotionLis
                 int id = enemy.getEnemyData().getID();
                 MapSprite sprite = enemy.getEnemyData().getMapSprite();
                 if(sprite == null){
-                    targetX += enemy.getEnemyData().getID()+1 < 10 ? 0 : -4;
+                    targetX += 8 + ((enemy.getEnemyData().getID()+1 < 10) ? 0 : -4);
+                    targetY += 3;
                     g2.setColor(Color.black);
                     g2.drawString(String.valueOf(id), targetX-1, targetY+16-1);
                     g2.drawString(String.valueOf(id), targetX-1, targetY+16+1);

--- a/src/com/sfc/sf2/battle/gui/BattlePanel.java
+++ b/src/com/sfc/sf2/battle/gui/BattlePanel.java
@@ -55,6 +55,8 @@ public class BattlePanel extends JPanel implements MouseListener, MouseMotionLis
     
     private int lastMouseX = 0;
     private int lastMouseY = 0;
+    private int battleCoordsOffsetX = 0;
+    private int battleCoordsOffsetY = 0;    
     private TitledBorder titledBorder = null;
     private JPanel titledPanel = null;
     
@@ -145,6 +147,9 @@ public class BattlePanel extends JPanel implements MouseListener, MouseMotionLis
         renderCounter++;
         System.out.println("Map render "+renderCounter);
         this.battle = battle;
+        battleCoordsOffsetX = battle.getMapCoords().getX();
+        battleCoordsOffsetY = battle.getMapCoords().getY();
+            
         if(redraw){
             MapBlock[] blocks = layout.getBlocks();
             int imageHeight = 64*3*8;
@@ -639,7 +644,7 @@ public class BattlePanel extends JPanel implements MouseListener, MouseMotionLis
             lastMouseX=x;
             lastMouseY=y;
             titledBorder = (TitledBorder)(titledPanel.getBorder());
-            titledBorder.setTitle("Cursor : "+x+","+y);
+            titledBorder.setTitle("Cursor : "+x+","+y+"\t (battle : "+(x-battleCoordsOffsetX)+", "+(y-battleCoordsOffsetY)+")");
             titledPanel.revalidate();
             titledPanel.repaint();
             //System.out.println("New cursor pos : "+x+","+y);

--- a/src/com/sfc/sf2/battle/gui/EnemyPropertiesTableModel.java
+++ b/src/com/sfc/sf2/battle/gui/EnemyPropertiesTableModel.java
@@ -101,7 +101,7 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
         for(int i=0;i<tableData.length;i++){
             newTable[i] = tableData[i];
         }
-        newTable[newTable.length-1] = new Integer[11];
+        newTable[newTable.length-1] = new Object[11];
         newTable[newTable.length-1][0] = tableData[tableData.length-1][0];
         newTable[newTable.length-1][1] = 0;
         newTable[newTable.length-1][2] = 0;
@@ -136,7 +136,7 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
     
     @Override
     public Class getColumnClass(int column) {
-        return Integer.class;
+        return Object.class;
     }    
     
     @Override
@@ -145,7 +145,7 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
     }
     @Override
     public void setValueAt(Object value, int row, int col) {
-        tableData[row][col] = (Integer)value;
+        tableData[row][col] = value;
         updateProperties();
         battlePanel.updateSpriteDisplay();
         battlePanel.revalidate();

--- a/src/com/sfc/sf2/battle/gui/EnemyPropertiesTableModel.java
+++ b/src/com/sfc/sf2/battle/gui/EnemyPropertiesTableModel.java
@@ -41,9 +41,9 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
                 tableData[i][3] = enemies[i].getAi();
                 tableData[i][4] = enemies[i].getItem();
                 tableData[i][5] = enemies[i].getMoveOrder1();
-                tableData[i][6] = enemies[i].getTriggerRegion();
-                tableData[i][7] = enemies[i].getByte8();
-                tableData[i][8] = enemies[i].getByte9();
+                tableData[i][6] = enemies[i].getTriggerRegion1();
+                tableData[i][7] = enemies[i].getMoveOrder2();
+                tableData[i][8] = enemies[i].getTriggerRegion2();
                 tableData[i][9] = enemies[i].getByte10();
                 tableData[i][10] = enemies[i].getSpawnParams();
                 i++;
@@ -84,9 +84,9 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
                 enemy.setAi((int)entry[3]);
                 enemy.setItem((int)entry[4]);
                 enemy.setMoveOrder1((int)entry[5]);
-                enemy.setTriggerRegion((int)entry[6]);
-                enemy.setByte8((int)entry[7]);
-                enemy.setByte9((int)entry[8]);
+                enemy.setTriggerRegion1((int)entry[6]);
+                enemy.setMoveOrder2((int)entry[7]);
+                enemy.setTriggerRegion2((int)entry[8]);
                 enemy.setByte10((int)entry[9]);
                 enemy.setSpawnParams((int)entry[10]);
                 entries.add(enemy);

--- a/src/com/sfc/sf2/battle/gui/EnemyPropertiesTableModel.java
+++ b/src/com/sfc/sf2/battle/gui/EnemyPropertiesTableModel.java
@@ -7,6 +7,7 @@ package com.sfc.sf2.battle.gui;
 
 import com.sfc.sf2.battle.Battle;
 import com.sfc.sf2.battle.Enemy;
+import com.sfc.sf2.battle.EnemyData;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.table.AbstractTableModel;
@@ -17,22 +18,24 @@ import javax.swing.table.AbstractTableModel;
  */
 public class EnemyPropertiesTableModel extends AbstractTableModel {
     
-    private Integer[][] tableData;
-    private final String[] columns = {"Index", "X", "Y", "AI", "Item", "Order 1", "Region 1", "Order 2", "Region 2", "Byte10", "Spawn"};
+    private Object[][] tableData;
+    private final String[] columns = {"Name", "X", "Y", "AI", "Item", "Order 1", "Region 1", "Order 2", "Region 2", "Byte10", "Spawn"};
     private Battle battle;
     private BattlePanel battlePanel;
+    private EnemyData[] enemyData;
     
-    public EnemyPropertiesTableModel(Battle battle, BattlePanel battlePanel) {
+    public EnemyPropertiesTableModel(Battle battle, BattlePanel battlePanel, EnemyData[] enemyData) {
         super();
         this.battle = battle;
         this.battlePanel = battlePanel;
+        this.enemyData = enemyData;
         Enemy[] enemies = battle.getSpriteset().getEnemies();
-        tableData = new Integer[enemies.length][];
+        tableData = new Object[enemies.length][];
         int i = 0;
         if(enemies!=null){
             while(i<enemies.length){
-                tableData[i] = new Integer[11];
-                tableData[i][0] = enemies[i].getIndex();
+                tableData[i] = new Object[11];
+                tableData[i][0] = enemies[i].getEnemyData().getName();
                 tableData[i][1] = enemies[i].getX();
                 tableData[i][2] = enemies[i].getY();
                 tableData[i][3] = enemies[i].getAi();
@@ -47,14 +50,14 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
             }
         }
         while(i<tableData.length){
-            tableData[i] = new Integer[11];
+            tableData[i] = new Object[11];
             i++;
         }
     }
     
     public void updateProperties() {
         List<Enemy> entries = new ArrayList<>();
-        for(Integer[] entry : tableData){
+        for(Object[] entry : tableData){
             if(entry[0] != null && entry[1] != null
                     && entry[2] != null && entry[3] != null
                     && entry[4] != null && entry[5] != null
@@ -62,17 +65,30 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
                     && entry[8] != null && entry[9] != null
                     && entry[10] != null){
                 Enemy enemy = new Enemy();
-                enemy.setIndex(entry[0]);
-                enemy.setX(entry[1]);
-                enemy.setY(entry[2]);
-                enemy.setAi(entry[3]); 
-                enemy.setItem(entry[4]);
-                enemy.setMoveOrder1(entry[5]);
-                enemy.setTriggerRegion(entry[6]);
-                enemy.setByte8(entry[7]); 
-                enemy.setByte9(entry[8]);
-                enemy.setByte10(entry[9]);
-                enemy.setSpawnParams(entry[10]);         
+                boolean matchFound = false;
+                for (int i = 0; i < enemyData.length; i++) {
+                    if (enemyData[i] != null && enemyData[i].getName().equals(entry[0])){
+                        enemy.setEnemyData(enemyData[i]);
+                        matchFound = true;
+                        break;
+                    }
+                }
+                if (!matchFound){
+                    EnemyData data = new EnemyData();
+                    data.setName(String.valueOf(entry[0]));
+                    enemy.setEnemyData(data);
+                }
+                
+                enemy.setX((int)entry[1]);
+                enemy.setY((int)entry[2]);
+                enemy.setAi((int)entry[3]);
+                enemy.setItem((int)entry[4]);
+                enemy.setMoveOrder1((int)entry[5]);
+                enemy.setTriggerRegion((int)entry[6]);
+                enemy.setByte8((int)entry[7]);
+                enemy.setByte9((int)entry[8]);
+                enemy.setByte10((int)entry[9]);
+                enemy.setSpawnParams((int)entry[10]);
                 entries.add(enemy);
             }
         }
@@ -81,7 +97,7 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
     }
     
     public void addRow(){
-        Integer[][] newTable = new Integer[tableData.length+1][];
+        Object[][] newTable = new Object[tableData.length+1][];
         for(int i=0;i<tableData.length;i++){
             newTable[i] = tableData[i];
         }
@@ -106,7 +122,7 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
     
     public void removeRow(){
         if(tableData.length>1){
-            Integer[][] newTable = new Integer[tableData.length-1][];
+            Object[][] newTable = new Object[tableData.length-1][];
             for(int i=0;i<newTable.length;i++){
                 newTable[i] = tableData[i];
             }
@@ -162,6 +178,14 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
 
     public void setBattle(Battle battle) {
         this.battle = battle;
+    }
+
+    public EnemyData[] getEnemyData() {
+        return enemyData;
+    }
+
+    public void setEnemyData(EnemyData[] enemyData) {
+        this.enemyData = enemyData;
     }
     
 }

--- a/src/com/sfc/sf2/battle/gui/EnemyPropertiesTableModel.java
+++ b/src/com/sfc/sf2/battle/gui/EnemyPropertiesTableModel.java
@@ -79,15 +79,15 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
                     enemy.setEnemyData(data);
                 }
                 
-                enemy.setX((int)entry[1]);
-                enemy.setY((int)entry[2]);
+                enemy.setX((entry[1] instanceof String) ? Integer.parseInt((String)entry[1]) : (int)entry[1]);
+                enemy.setY((entry[2] instanceof String) ? Integer.parseInt((String)entry[2]) : (int)entry[2]);
                 enemy.setAi((String)entry[3]);
                 enemy.setItem((String)entry[4]);
                 enemy.setMoveOrder1((String)entry[5]);
-                enemy.setTriggerRegion1((int)entry[6]);
+                enemy.setTriggerRegion1((entry[6] instanceof String) ? Integer.parseInt((String)entry[6]) : (int)entry[6]);
                 enemy.setMoveOrder2((String)entry[7]);
-                enemy.setTriggerRegion2((int)entry[8]);
-                enemy.setByte10((int)entry[9]);
+                enemy.setTriggerRegion2((entry[8] instanceof String) ? Integer.parseInt((String)entry[8]) : (int)entry[8]);
+                enemy.setByte10((entry[9] instanceof String) ? Integer.parseInt((String)entry[9]) : (int)entry[9]);
                 enemy.setSpawnParams((String)entry[10]);
                 entries.add(enemy);
             }
@@ -150,7 +150,8 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
         battlePanel.updateSpriteDisplay();
         battlePanel.revalidate();
         battlePanel.repaint();
-    }    
+        this.fireTableCellUpdated(row, col);
+    }
  
     @Override
     public boolean isCellEditable(int rowIndex, int columnIndex) {

--- a/src/com/sfc/sf2/battle/gui/EnemyPropertiesTableModel.java
+++ b/src/com/sfc/sf2/battle/gui/EnemyPropertiesTableModel.java
@@ -81,14 +81,14 @@ public class EnemyPropertiesTableModel extends AbstractTableModel {
                 
                 enemy.setX((int)entry[1]);
                 enemy.setY((int)entry[2]);
-                enemy.setAi((int)entry[3]);
-                enemy.setItem((int)entry[4]);
-                enemy.setMoveOrder1((int)entry[5]);
+                enemy.setAi((String)entry[3]);
+                enemy.setItem((String)entry[4]);
+                enemy.setMoveOrder1((String)entry[5]);
                 enemy.setTriggerRegion1((int)entry[6]);
-                enemy.setMoveOrder2((int)entry[7]);
+                enemy.setMoveOrder2((String)entry[7]);
                 enemy.setTriggerRegion2((int)entry[8]);
                 enemy.setByte10((int)entry[9]);
-                enemy.setSpawnParams((int)entry[10]);
+                enemy.setSpawnParams((String)entry[10]);
                 entries.add(enemy);
             }
         }

--- a/src/com/sfc/sf2/battle/gui/MainEditor.form
+++ b/src/com/sfc/sf2/battle/gui/MainEditor.form
@@ -1371,13 +1371,6 @@
                                                   <Component id="jButton31" min="-2" max="-2" attributes="0"/>
                                               </Group>
                                               <Group type="102" alignment="0" attributes="0">
-                                                  <Component id="jLabel31" min="-2" max="-2" attributes="0"/>
-                                                  <EmptySpace max="-2" attributes="0"/>
-                                                  <Component id="jTextField29" pref="0" max="32767" attributes="0"/>
-                                                  <EmptySpace max="-2" attributes="0"/>
-                                                  <Component id="jButton36" min="-2" max="-2" attributes="0"/>
-                                              </Group>
-                                              <Group type="102" alignment="0" attributes="0">
                                                   <Component id="jLabel22" min="-2" max="-2" attributes="0"/>
                                                   <EmptySpace max="-2" attributes="0"/>
                                                   <Component id="jTextField30" pref="0" max="32767" attributes="0"/>
@@ -1463,13 +1456,7 @@
                                                       <Component id="jLabel32" alignment="3" min="-2" max="-2" attributes="0"/>
                                                       <Component id="jButton37" alignment="3" min="-2" max="-2" attributes="0"/>
                                                   </Group>
-                                                  <EmptySpace max="-2" attributes="0"/>
-                                                  <Group type="103" groupAlignment="3" attributes="0">
-                                                      <Component id="jTextField29" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                      <Component id="jLabel31" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                      <Component id="jButton36" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                  </Group>
-                                                  <EmptySpace max="-2" attributes="0"/>
+                                                  <EmptySpace min="-2" max="-2" attributes="0"/>
                                                   <Group type="103" groupAlignment="3" attributes="0">
                                                       <Component id="jSpinner4" alignment="3" min="-2" max="-2" attributes="0"/>
                                                       <Component id="jLabel10" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -1490,7 +1477,7 @@
                                                   <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
                                                   <EmptySpace max="-2" attributes="0"/>
                                                   <Component id="jButton18" min="-2" max="-2" attributes="0"/>
-                                                  <EmptySpace pref="240" max="32767" attributes="0"/>
+                                                  <EmptySpace pref="273" max="32767" attributes="0"/>
                                               </Group>
                                           </Group>
                                         </DimensionLayout>
@@ -1666,27 +1653,6 @@
                                           </Properties>
                                           <Events>
                                             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButton32ActionPerformed"/>
-                                          </Events>
-                                        </Component>
-                                        <Component class="javax.swing.JLabel" name="jLabel31">
-                                          <Properties>
-                                            <Property name="text" type="java.lang.String" value="Enemy sprites :"/>
-                                          </Properties>
-                                        </Component>
-                                        <Component class="javax.swing.JTextField" name="jTextField29">
-                                          <Properties>
-                                            <Property name="text" type="java.lang.String" value="..\u005cstats\u005cenemies\u005cenemymapsprites.asm" containsInvalidXMLChars="true"/>
-                                          </Properties>
-                                          <Events>
-                                            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextField29ActionPerformed"/>
-                                          </Events>
-                                        </Component>
-                                        <Component class="javax.swing.JButton" name="jButton36">
-                                          <Properties>
-                                            <Property name="text" type="java.lang.String" value="File..."/>
-                                          </Properties>
-                                          <Events>
-                                            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButton36ActionPerformed"/>
                                           </Events>
                                         </Component>
                                         <Component class="javax.swing.JLabel" name="jLabel22">

--- a/src/com/sfc/sf2/battle/gui/MainEditor.form
+++ b/src/com/sfc/sf2/battle/gui/MainEditor.form
@@ -1907,7 +1907,7 @@
                                         </Component>
                                         <Component class="javax.swing.JTextField" name="jTextField28">
                                           <Properties>
-                                            <Property name="text" type="java.lang.String" value=".\u005centries\u005cbattle01\u005cspriteset.bin" containsInvalidXMLChars="true"/>
+                                            <Property name="text" type="java.lang.String" value=".\u005cspritesets\u005cspriteset01.asm" containsInvalidXMLChars="true"/>
                                           </Properties>
                                           <Events>
                                             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextField28ActionPerformed"/>

--- a/src/com/sfc/sf2/battle/gui/MainEditor.form
+++ b/src/com/sfc/sf2/battle/gui/MainEditor.form
@@ -19,7 +19,7 @@
     <Property name="title" type="java.lang.String" value="SF2BattleEditor"/>
   </Properties>
   <SyntheticProperties>
-    <SyntheticProperty name="formSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,3,70,0,0,3,-8"/>
+    <SyntheticProperty name="formSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,3,70,0,0,4,69"/>
     <SyntheticProperty name="formSizePolicy" type="int" value="0"/>
     <SyntheticProperty name="generateSize" type="boolean" value="true"/>
     <SyntheticProperty name="generateCenter" type="boolean" value="true"/>
@@ -54,7 +54,7 @@
       <Layout>
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
-              <Component id="jSplitPane1" alignment="0" max="32767" attributes="0"/>
+              <Component id="jSplitPane1" alignment="0" pref="1077" max="32767" attributes="0"/>
           </Group>
         </DimensionLayout>
         <DimensionLayout dim="1">
@@ -111,7 +111,8 @@
                       <Layout>
                         <DimensionLayout dim="0">
                           <Group type="103" groupAlignment="0" attributes="0">
-                              <Group type="102" alignment="1" attributes="0">
+                              <Group type="102" attributes="0">
+                                  <EmptySpace max="-2" attributes="0"/>
                                   <Component id="jPanel1" max="32767" attributes="0"/>
                                   <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
                               </Group>
@@ -136,12 +137,12 @@
                           <Layout>
                             <DimensionLayout dim="0">
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="jScrollPane2" alignment="0" pref="436" max="32767" attributes="0"/>
+                                  <Component id="jScrollPane2" alignment="0" pref="512" max="32767" attributes="0"/>
                               </Group>
                             </DimensionLayout>
                             <DimensionLayout dim="1">
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="jScrollPane2" alignment="0" pref="694" max="32767" attributes="0"/>
+                                  <Component id="jScrollPane2" alignment="0" pref="749" max="32767" attributes="0"/>
                               </Group>
                             </DimensionLayout>
                           </Layout>
@@ -159,12 +160,12 @@
                                   <Layout>
                                     <DimensionLayout dim="0">
                                       <Group type="103" groupAlignment="0" attributes="0">
-                                          <EmptySpace min="0" pref="858" max="32767" attributes="0"/>
+                                          <EmptySpace min="0" pref="824" max="32767" attributes="0"/>
                                       </Group>
                                     </DimensionLayout>
                                     <DimensionLayout dim="1">
                                       <Group type="103" groupAlignment="0" attributes="0">
-                                          <EmptySpace min="0" pref="715" max="32767" attributes="0"/>
+                                          <EmptySpace min="0" pref="739" max="32767" attributes="0"/>
                                       </Group>
                                     </DimensionLayout>
                                   </Layout>
@@ -324,7 +325,7 @@
                                                       <Component id="jSpinner8" alignment="3" min="-2" max="-2" attributes="0"/>
                                                       <Component id="jLabel11" alignment="3" min="-2" max="-2" attributes="0"/>
                                                   </Group>
-                                                  <EmptySpace pref="446" max="32767" attributes="0"/>
+                                                  <EmptySpace pref="470" max="32767" attributes="0"/>
                                               </Group>
                                           </Group>
                                         </DimensionLayout>
@@ -628,7 +629,7 @@
                                                                   <Component id="jButton1" alignment="3" min="-2" max="-2" attributes="0"/>
                                                                   <Component id="jButton3" alignment="3" min="-2" max="-2" attributes="0"/>
                                                               </Group>
-                                                              <EmptySpace pref="19" max="32767" attributes="0"/>
+                                                              <EmptySpace pref="51" max="32767" attributes="0"/>
                                                           </Group>
                                                       </Group>
                                                     </DimensionLayout>
@@ -674,7 +675,7 @@
                                                           <Component id="jButton5" min="-2" max="-2" attributes="0"/>
                                                           <EmptySpace max="32767" attributes="0"/>
                                                       </Group>
-                                                      <Component id="jPanel17" alignment="0" max="32767" attributes="0"/>
+                                                      <Component id="jPanel17" alignment="0" pref="285" max="32767" attributes="0"/>
                                                   </Group>
                                                 </DimensionLayout>
                                                 <DimensionLayout dim="1">
@@ -755,66 +756,76 @@
                                                               <EmptySpace max="-2" attributes="0"/>
                                                               <Group type="103" groupAlignment="0" attributes="0">
                                                                   <Group type="102" alignment="0" attributes="0">
-                                                                      <Component id="jLabel39" min="-2" max="-2" attributes="0"/>
+                                                                      <Component id="jLabel35" min="-2" max="-2" attributes="0"/>
                                                                       <EmptySpace max="-2" attributes="0"/>
-                                                                      <Component id="jSpinner21" min="-2" pref="40" max="-2" attributes="0"/>
-                                                                      <EmptySpace min="-2" pref="24" max="-2" attributes="0"/>
-                                                                      <Component id="jLabel40" min="-2" max="-2" attributes="0"/>
+                                                                      <Component id="jComboBox_Order2" min="-2" max="-2" attributes="0"/>
+                                                                  </Group>
+                                                                  <Group type="102" alignment="0" attributes="0">
+                                                                      <Component id="jLabel36" min="-2" max="-2" attributes="0"/>
                                                                       <EmptySpace max="-2" attributes="0"/>
-                                                                      <Component id="jSpinner22" min="-2" pref="40" max="-2" attributes="0"/>
+                                                                      <Component id="jComboBox_Order1" min="-2" max="-2" attributes="0"/>
+                                                                  </Group>
+                                                                  <Group type="103" alignment="0" groupAlignment="1" max="-2" attributes="0">
+                                                                      <Group type="102" alignment="0" attributes="0">
+                                                                          <Component id="jLabel38" min="-2" pref="72" max="-2" attributes="0"/>
+                                                                          <EmptySpace max="-2" attributes="0"/>
+                                                                          <Component id="jSpinner_Trigger2" pref="0" max="32767" attributes="0"/>
+                                                                      </Group>
+                                                                      <Group type="102" alignment="0" attributes="0">
+                                                                          <Component id="jLabel37" min="-2" max="-2" attributes="0"/>
+                                                                          <EmptySpace min="-2" pref="14" max="-2" attributes="0"/>
+                                                                          <Component id="jSpinner_Trigger1" min="-2" pref="55" max="-2" attributes="0"/>
+                                                                      </Group>
+                                                                  </Group>
+                                                                  <Group type="102" alignment="0" attributes="0">
+                                                                      <Group type="103" groupAlignment="0" attributes="0">
+                                                                          <Component id="jLabel19" alignment="0" min="-2" max="-2" attributes="0"/>
+                                                                          <Component id="jLabel34" alignment="0" min="-2" max="-2" attributes="0"/>
+                                                                      </Group>
+                                                                      <EmptySpace max="-2" attributes="0"/>
+                                                                      <Group type="103" groupAlignment="1" attributes="0">
+                                                                          <Group type="102" attributes="0">
+                                                                              <Component id="jComboBox_AI" min="-2" max="-2" attributes="0"/>
+                                                                              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                                                              <Component id="jLabel40" min="-2" pref="48" max="-2" attributes="0"/>
+                                                                              <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
+                                                                              <Component id="jComboBox_Spawn" min="-2" pref="99" max="-2" attributes="0"/>
+                                                                          </Group>
+                                                                          <Group type="103" groupAlignment="1" max="-2" attributes="0">
+                                                                              <Group type="102" attributes="0">
+                                                                                  <EmptySpace min="-2" pref="130" max="-2" attributes="0"/>
+                                                                                  <Component id="jLabel41" min="-2" pref="48" max="-2" attributes="0"/>
+                                                                                  <EmptySpace max="32767" attributes="0"/>
+                                                                                  <Component id="jSpinner_OrderTarget1" min="-2" pref="55" max="-2" attributes="0"/>
+                                                                              </Group>
+                                                                              <Group type="102" attributes="0">
+                                                                                  <Component id="jComboBox_Items" min="-2" max="-2" attributes="0"/>
+                                                                                  <EmptySpace max="-2" attributes="0"/>
+                                                                                  <Component id="jTextField_ItemFlags" min="-2" pref="149" max="-2" attributes="0"/>
+                                                                              </Group>
+                                                                              <Group type="102" alignment="1" attributes="0">
+                                                                                  <Component id="jLabel42" min="-2" pref="48" max="-2" attributes="0"/>
+                                                                                  <EmptySpace max="-2" attributes="0"/>
+                                                                                  <Component id="jSpinner_OrderTarget2" min="-2" pref="55" max="-2" attributes="0"/>
+                                                                              </Group>
+                                                                          </Group>
+                                                                      </Group>
                                                                   </Group>
                                                                   <Group type="102" attributes="0">
-                                                                      <Group type="103" groupAlignment="0" attributes="0">
-                                                                          <Group type="103" alignment="0" groupAlignment="0" max="-2" attributes="0">
-                                                                              <Group type="102" attributes="0">
-                                                                                  <Component id="jLabel16" min="-2" max="-2" attributes="0"/>
-                                                                                  <EmptySpace max="-2" attributes="0"/>
-                                                                                  <Component id="jSpinner12" min="-2" pref="40" max="-2" attributes="0"/>
-                                                                              </Group>
-                                                                              <Group type="102" alignment="0" attributes="0">
-                                                                                  <Component id="jLabel35" min="-2" max="-2" attributes="0"/>
-                                                                                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                                                                                  <Component id="jSpinner17" min="-2" pref="40" max="-2" attributes="0"/>
-                                                                                  <EmptySpace max="32767" attributes="0"/>
-                                                                                  <Component id="jLabel38" min="-2" max="-2" attributes="0"/>
-                                                                              </Group>
-                                                                              <Group type="102" alignment="0" attributes="0">
-                                                                                  <Group type="103" groupAlignment="1" attributes="0">
-                                                                                      <Group type="102" attributes="0">
-                                                                                          <Component id="jLabel19" min="-2" max="-2" attributes="0"/>
-                                                                                          <EmptySpace min="-2" pref="30" max="-2" attributes="0"/>
-                                                                                          <Component id="jSpinner15" min="-2" pref="40" max="-2" attributes="0"/>
-                                                                                      </Group>
-                                                                                      <Group type="102" attributes="0">
-                                                                                          <Component id="jLabel36" min="-2" max="-2" attributes="0"/>
-                                                                                          <EmptySpace max="-2" attributes="0"/>
-                                                                                          <Component id="jSpinner18" min="-2" pref="40" max="-2" attributes="0"/>
-                                                                                      </Group>
-                                                                                  </Group>
-                                                                                  <EmptySpace pref="32" max="32767" attributes="0"/>
-                                                                                  <Group type="103" groupAlignment="0" attributes="0">
-                                                                                      <Component id="jLabel37" alignment="1" min="-2" max="-2" attributes="0"/>
-                                                                                      <Component id="jLabel34" alignment="1" min="-2" max="-2" attributes="0"/>
-                                                                                      <Component id="jLabel18" alignment="1" min="-2" max="-2" attributes="0"/>
-                                                                                  </Group>
-                                                                              </Group>
-                                                                          </Group>
-                                                                          <Group type="102" alignment="0" attributes="0">
-                                                                              <Component id="jLabel17" min="-2" max="-2" attributes="0"/>
-                                                                              <EmptySpace min="-2" pref="35" max="-2" attributes="0"/>
-                                                                              <Component id="jSpinner13" min="-2" pref="40" max="-2" attributes="0"/>
-                                                                          </Group>
-                                                                      </Group>
+                                                                      <Component id="jLabel16" min="-2" max="-2" attributes="0"/>
                                                                       <EmptySpace max="-2" attributes="0"/>
-                                                                      <Group type="103" groupAlignment="0" attributes="0">
-                                                                          <Component id="jSpinner20" min="-2" pref="40" max="-2" attributes="0"/>
-                                                                          <Component id="jSpinner19" min="-2" pref="40" max="-2" attributes="0"/>
-                                                                          <Component id="jSpinner16" min="-2" pref="40" max="-2" attributes="0"/>
-                                                                          <Component id="jSpinner14" min="-2" pref="40" max="-2" attributes="0"/>
-                                                                      </Group>
+                                                                      <Component id="jComboBox_Name" min="-2" max="-2" attributes="0"/>
+                                                                      <EmptySpace max="-2" attributes="0"/>
+                                                                      <Component id="jLabel17" min="-2" max="-2" attributes="0"/>
+                                                                      <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
+                                                                      <Component id="jSpinner_X" min="-2" pref="46" max="-2" attributes="0"/>
+                                                                      <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
+                                                                      <Component id="jLabel18" min="-2" max="-2" attributes="0"/>
+                                                                      <EmptySpace max="-2" attributes="0"/>
+                                                                      <Component id="jSpinner_Y" min="-2" pref="49" max="-2" attributes="0"/>
                                                                   </Group>
                                                               </Group>
-                                                              <EmptySpace min="0" pref="26" max="32767" attributes="0"/>
+                                                              <EmptySpace max="32767" attributes="0"/>
                                                           </Group>
                                                       </Group>
                                                     </DimensionLayout>
@@ -823,43 +834,57 @@
                                                           <Group type="102" alignment="0" attributes="0">
                                                               <EmptySpace max="-2" attributes="0"/>
                                                               <Group type="103" groupAlignment="3" attributes="0">
-                                                                  <Component id="jSpinner12" alignment="3" min="-2" max="-2" attributes="0"/>
                                                                   <Component id="jLabel16" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                              </Group>
-                                                              <EmptySpace pref="27" max="32767" attributes="0"/>
-                                                              <Group type="103" groupAlignment="3" attributes="0">
-                                                                  <Component id="jSpinner13" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                  <Component id="jComboBox_Name" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                  <Component id="jSpinner_X" alignment="3" min="-2" max="-2" attributes="0"/>
                                                                   <Component id="jLabel17" alignment="3" min="-2" max="-2" attributes="0"/>
                                                                   <Component id="jLabel18" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jSpinner14" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                  <Component id="jSpinner_Y" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                              </Group>
+                                                              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                                              <Group type="103" groupAlignment="3" attributes="0">
+                                                                  <Component id="jLabel19" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                  <Component id="jComboBox_AI" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                  <Component id="jLabel40" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                  <Component id="jComboBox_Spawn" alignment="3" min="-2" max="-2" attributes="0"/>
                                                               </Group>
                                                               <EmptySpace max="-2" attributes="0"/>
                                                               <Group type="103" groupAlignment="3" attributes="0">
-                                                                  <Component id="jSpinner15" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jLabel19" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jSpinner16" alignment="3" min="-2" max="-2" attributes="0"/>
                                                                   <Component id="jLabel34" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                  <Component id="jComboBox_Items" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                  <Component id="jTextField_ItemFlags" alignment="3" min="-2" max="-2" attributes="0"/>
                                                               </Group>
                                                               <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                                                              <Group type="103" groupAlignment="3" attributes="0">
-                                                                  <Component id="jSpinner18" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jLabel36" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jSpinner19" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jLabel37" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                              <Group type="103" groupAlignment="0" attributes="0">
+                                                                  <Group type="102" attributes="0">
+                                                                      <Group type="103" groupAlignment="3" attributes="0">
+                                                                          <Component id="jLabel36" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                          <Component id="jComboBox_Order1" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                      </Group>
+                                                                      <EmptySpace max="-2" attributes="0"/>
+                                                                      <Group type="103" groupAlignment="3" attributes="0">
+                                                                          <Component id="jLabel37" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                          <Component id="jSpinner_Trigger1" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                      </Group>
+                                                                      <EmptySpace max="-2" attributes="0"/>
+                                                                      <Group type="103" groupAlignment="3" attributes="0">
+                                                                          <Component id="jLabel35" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                          <Component id="jComboBox_Order2" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                          <Group type="103" alignment="3" groupAlignment="3" attributes="0">
+                                                                              <Component id="jLabel42" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                              <Component id="jSpinner_OrderTarget2" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                          </Group>
+                                                                      </Group>
+                                                                  </Group>
+                                                                  <Group type="103" groupAlignment="3" attributes="0">
+                                                                      <Component id="jLabel41" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                      <Component id="jSpinner_OrderTarget1" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                  </Group>
                                                               </Group>
-                                                              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                                              <EmptySpace max="-2" attributes="0"/>
                                                               <Group type="103" groupAlignment="3" attributes="0">
-                                                                  <Component id="jSpinner17" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jLabel35" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jSpinner20" alignment="3" min="-2" max="-2" attributes="0"/>
                                                                   <Component id="jLabel38" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                              </Group>
-                                                              <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                                                              <Group type="103" groupAlignment="3" attributes="0">
-                                                                  <Component id="jSpinner21" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jLabel39" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jSpinner22" alignment="3" min="-2" max="-2" attributes="0"/>
-                                                                  <Component id="jLabel40" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                                  <Component id="jSpinner_Trigger2" alignment="3" min="-2" max="-2" attributes="0"/>
                                                               </Group>
                                                               <EmptySpace max="-2" attributes="0"/>
                                                           </Group>
@@ -869,45 +894,32 @@
                                                   <SubComponents>
                                                     <Component class="javax.swing.JLabel" name="jLabel16">
                                                       <Properties>
-                                                        <Property name="text" type="java.lang.String" value="Index :"/>
+                                                        <Property name="text" type="java.lang.String" value="Name :"/>
                                                       </Properties>
-                                                    </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner12">
-                                                      <Properties>
-                                                        <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
-                                                          <SpinnerModel initial="1" maximum="12" minimum="1" numberType="java.lang.Integer" stepSize="1" type="number"/>
-                                                        </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
-                                                      </Properties>
-                                                      <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner12StateChanged"/>
-                                                      </Events>
                                                     </Component>
                                                     <Component class="javax.swing.JLabel" name="jLabel17">
                                                       <Properties>
                                                         <Property name="text" type="java.lang.String" value="X :"/>
                                                       </Properties>
                                                     </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner13">
+                                                    <Component class="javax.swing.JSpinner" name="jSpinner_X">
                                                       <Properties>
                                                         <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
                                                           <SpinnerModel initial="0" maximum="63" minimum="0" numberType="java.lang.Integer" stepSize="1" type="number"/>
                                                         </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
                                                       </Properties>
                                                       <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner13StateChanged"/>
+                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner_XStateChanged"/>
                                                       </Events>
                                                     </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner14">
+                                                    <Component class="javax.swing.JSpinner" name="jSpinner_Y">
                                                       <Properties>
                                                         <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
                                                           <SpinnerModel initial="0" maximum="63" minimum="0" numberType="java.lang.Integer" stepSize="1" type="number"/>
                                                         </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
                                                       </Properties>
                                                       <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner14StateChanged"/>
+                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner_YStateChanged"/>
                                                       </Events>
                                                     </Component>
                                                     <Component class="javax.swing.JLabel" name="jLabel18">
@@ -920,127 +932,200 @@
                                                         <Property name="text" type="java.lang.String" value="AI :"/>
                                                       </Properties>
                                                     </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner15">
+                                                    <Component class="javax.swing.JComboBox" name="jComboBox_Name">
                                                       <Properties>
-                                                        <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
-                                                          <SpinnerModel initial="1" maximum="12" minimum="1" numberType="java.lang.Integer" stepSize="1" type="number"/>
+                                                        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+                                                          <StringArray count="4">
+                                                            <StringItem index="0" value="Item 1"/>
+                                                            <StringItem index="1" value="Item 2"/>
+                                                            <StringItem index="2" value="Item 3"/>
+                                                            <StringItem index="3" value="Item 4"/>
+                                                          </StringArray>
                                                         </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
                                                       </Properties>
                                                       <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner15StateChanged"/>
+                                                        <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="jComboBox_NameItemStateChanged"/>
                                                       </Events>
+                                                      <AuxValues>
+                                                        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+                                                      </AuxValues>
+                                                    </Component>
+                                                    <Component class="javax.swing.JComboBox" name="jComboBox_AI">
+                                                      <Properties>
+                                                        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+                                                          <StringArray count="4">
+                                                            <StringItem index="0" value="Item 1"/>
+                                                            <StringItem index="1" value="Item 2"/>
+                                                            <StringItem index="2" value="Item 3"/>
+                                                            <StringItem index="3" value="Item 4"/>
+                                                          </StringArray>
+                                                        </Property>
+                                                      </Properties>
+                                                      <Events>
+                                                        <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="jComboBox_AIItemStateChanged"/>
+                                                      </Events>
+                                                      <AuxValues>
+                                                        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+                                                      </AuxValues>
+                                                    </Component>
+                                                    <Component class="javax.swing.JComboBox" name="jComboBox_Spawn">
+                                                      <Properties>
+                                                        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+                                                          <StringArray count="4">
+                                                            <StringItem index="0" value="Item 1"/>
+                                                            <StringItem index="1" value="Item 2"/>
+                                                            <StringItem index="2" value="Item 3"/>
+                                                            <StringItem index="3" value="Item 4"/>
+                                                          </StringArray>
+                                                        </Property>
+                                                      </Properties>
+                                                      <Events>
+                                                        <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="jComboBox_SpawnItemStateChanged"/>
+                                                      </Events>
+                                                      <AuxValues>
+                                                        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+                                                      </AuxValues>
+                                                    </Component>
+                                                    <Component class="javax.swing.JLabel" name="jLabel40">
+                                                      <Properties>
+                                                        <Property name="text" type="java.lang.String" value="Spawn :"/>
+                                                      </Properties>
                                                     </Component>
                                                     <Component class="javax.swing.JLabel" name="jLabel34">
                                                       <Properties>
                                                         <Property name="text" type="java.lang.String" value="Item :"/>
                                                       </Properties>
                                                     </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner16">
+                                                    <Component class="javax.swing.JComboBox" name="jComboBox_Items">
                                                       <Properties>
-                                                        <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
-                                                          <SpinnerModel initial="0" maximum="63" minimum="0" numberType="java.lang.Integer" stepSize="1" type="number"/>
+                                                        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+                                                          <StringArray count="4">
+                                                            <StringItem index="0" value="Item 1"/>
+                                                            <StringItem index="1" value="Item 2"/>
+                                                            <StringItem index="2" value="Item 3"/>
+                                                            <StringItem index="3" value="Item 4"/>
+                                                          </StringArray>
                                                         </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
                                                       </Properties>
                                                       <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner16StateChanged"/>
+                                                        <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="jComboBox_ItemsItemStateChanged"/>
                                                       </Events>
+                                                      <AuxValues>
+                                                        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+                                                      </AuxValues>
                                                     </Component>
                                                     <Component class="javax.swing.JLabel" name="jLabel36">
                                                       <Properties>
-                                                        <Property name="text" type="java.lang.String" value="Order 1 :"/>
+                                                        <Property name="text" type="java.lang.String" value="Move Order 1 :"/>
                                                       </Properties>
                                                     </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner18">
+                                                    <Component class="javax.swing.JComboBox" name="jComboBox_Order1">
                                                       <Properties>
-                                                        <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
-                                                          <SpinnerModel initial="1" maximum="12" minimum="1" numberType="java.lang.Integer" stepSize="1" type="number"/>
+                                                        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+                                                          <StringArray count="4">
+                                                            <StringItem index="0" value="Item 1"/>
+                                                            <StringItem index="1" value="Item 2"/>
+                                                            <StringItem index="2" value="Item 3"/>
+                                                            <StringItem index="3" value="Item 4"/>
+                                                          </StringArray>
                                                         </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
                                                       </Properties>
                                                       <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner18StateChanged"/>
+                                                        <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="jComboBox_Order1ItemStateChanged"/>
                                                       </Events>
+                                                      <AuxValues>
+                                                        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+                                                      </AuxValues>
                                                     </Component>
                                                     <Component class="javax.swing.JLabel" name="jLabel37">
                                                       <Properties>
-                                                        <Property name="text" type="java.lang.String" value="Trig. Region :"/>
+                                                        <Property name="text" type="java.lang.String" value="Trig. Reg. 1 :"/>
                                                       </Properties>
                                                     </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner19">
+                                                    <Component class="javax.swing.JSpinner" name="jSpinner_Trigger1">
                                                       <Properties>
                                                         <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
                                                           <SpinnerModel initial="0" maximum="63" minimum="0" numberType="java.lang.Integer" stepSize="1" type="number"/>
                                                         </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
                                                       </Properties>
                                                       <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner19StateChanged"/>
+                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner_Trigger1StateChanged"/>
                                                       </Events>
                                                     </Component>
                                                     <Component class="javax.swing.JLabel" name="jLabel35">
                                                       <Properties>
-                                                        <Property name="text" type="java.lang.String" value="Byte 8 :"/>
+                                                        <Property name="text" type="java.lang.String" value="Move Order 2 :"/>
                                                       </Properties>
                                                     </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner17">
+                                                    <Component class="javax.swing.JComboBox" name="jComboBox_Order2">
                                                       <Properties>
-                                                        <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
-                                                          <SpinnerModel initial="1" maximum="12" minimum="1" numberType="java.lang.Integer" stepSize="1" type="number"/>
+                                                        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+                                                          <StringArray count="4">
+                                                            <StringItem index="0" value="Item 1"/>
+                                                            <StringItem index="1" value="Item 2"/>
+                                                            <StringItem index="2" value="Item 3"/>
+                                                            <StringItem index="3" value="Item 4"/>
+                                                          </StringArray>
                                                         </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
                                                       </Properties>
                                                       <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner17StateChanged"/>
+                                                        <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="jComboBox_Order2ItemStateChanged"/>
+                                                      </Events>
+                                                      <AuxValues>
+                                                        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+                                                      </AuxValues>
+                                                    </Component>
+                                                    <Component class="javax.swing.JLabel" name="jLabel41">
+                                                      <Properties>
+                                                        <Property name="text" type="java.lang.String" value="Target :"/>
+                                                      </Properties>
+                                                    </Component>
+                                                    <Component class="javax.swing.JSpinner" name="jSpinner_OrderTarget1">
+                                                      <Properties>
+                                                        <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
+                                                          <SpinnerModel initial="0" maximum="63" minimum="0" numberType="java.lang.Integer" stepSize="1" type="number"/>
+                                                        </Property>
+                                                      </Properties>
+                                                      <Events>
+                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner_OrderTarget1StateChanged"/>
+                                                      </Events>
+                                                    </Component>
+                                                    <Component class="javax.swing.JLabel" name="jLabel42">
+                                                      <Properties>
+                                                        <Property name="text" type="java.lang.String" value="Target :"/>
+                                                      </Properties>
+                                                    </Component>
+                                                    <Component class="javax.swing.JSpinner" name="jSpinner_OrderTarget2">
+                                                      <Properties>
+                                                        <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
+                                                          <SpinnerModel initial="0" maximum="63" minimum="0" numberType="java.lang.Integer" stepSize="1" type="number"/>
+                                                        </Property>
+                                                      </Properties>
+                                                      <Events>
+                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner_OrderTarget2StateChanged"/>
                                                       </Events>
                                                     </Component>
                                                     <Component class="javax.swing.JLabel" name="jLabel38">
                                                       <Properties>
-                                                        <Property name="text" type="java.lang.String" value="Byte 9 :"/>
+                                                        <Property name="text" type="java.lang.String" value="Trig. Reg. 2 :"/>
                                                       </Properties>
                                                     </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner20">
+                                                    <Component class="javax.swing.JSpinner" name="jSpinner_Trigger2">
                                                       <Properties>
                                                         <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
                                                           <SpinnerModel initial="0" maximum="63" minimum="0" numberType="java.lang.Integer" stepSize="1" type="number"/>
                                                         </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
                                                       </Properties>
                                                       <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner20StateChanged"/>
+                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner_Trigger2StateChanged"/>
                                                       </Events>
                                                     </Component>
-                                                    <Component class="javax.swing.JLabel" name="jLabel39">
+                                                    <Component class="javax.swing.JTextField" name="jTextField_ItemFlags">
                                                       <Properties>
-                                                        <Property name="text" type="java.lang.String" value="Byte 10 :"/>
-                                                      </Properties>
-                                                    </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner21">
-                                                      <Properties>
-                                                        <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
-                                                          <SpinnerModel initial="1" maximum="12" minimum="1" numberType="java.lang.Integer" stepSize="1" type="number"/>
-                                                        </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
+                                                        <Property name="text" type="java.lang.String" value="flags"/>
                                                       </Properties>
                                                       <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner21StateChanged"/>
-                                                      </Events>
-                                                    </Component>
-                                                    <Component class="javax.swing.JLabel" name="jLabel40">
-                                                      <Properties>
-                                                        <Property name="text" type="java.lang.String" value="Spawn param :"/>
-                                                      </Properties>
-                                                    </Component>
-                                                    <Component class="javax.swing.JSpinner" name="jSpinner22">
-                                                      <Properties>
-                                                        <Property name="model" type="javax.swing.SpinnerModel" editor="org.netbeans.modules.form.editors2.SpinnerModelEditor">
-                                                          <SpinnerModel initial="0" maximum="63" minimum="0" numberType="java.lang.Integer" stepSize="1" type="number"/>
-                                                        </Property>
-                                                        <Property name="enabled" type="boolean" value="false"/>
-                                                      </Properties>
-                                                      <Events>
-                                                        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="jSpinner22StateChanged"/>
+                                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextField_ItemFlagsActionPerformed"/>
                                                       </Events>
                                                     </Component>
                                                   </SubComponents>
@@ -1064,7 +1149,7 @@
                                                 </DimensionLayout>
                                                 <DimensionLayout dim="1">
                                                   <Group type="103" groupAlignment="0" attributes="0">
-                                                      <Component id="jScrollPane9" alignment="1" pref="527" max="32767" attributes="0"/>
+                                                      <Component id="jScrollPane9" alignment="1" pref="563" max="32767" attributes="0"/>
                                                   </Group>
                                                 </DimensionLayout>
                                               </Layout>
@@ -1115,7 +1200,7 @@
                                                 </DimensionLayout>
                                                 <DimensionLayout dim="1">
                                                   <Group type="103" groupAlignment="0" attributes="0">
-                                                      <Component id="jScrollPane14" alignment="1" pref="527" max="32767" attributes="0"/>
+                                                      <Component id="jScrollPane14" alignment="1" pref="563" max="32767" attributes="0"/>
                                                   </Group>
                                                 </DimensionLayout>
                                               </Layout>
@@ -1280,7 +1365,7 @@
                                 </DimensionLayout>
                                 <DimensionLayout dim="1">
                                   <Group type="103" groupAlignment="0" attributes="0">
-                                      <Component id="jTabbedPane1" alignment="1" pref="715" max="32767" attributes="0"/>
+                                      <Component id="jTabbedPane1" alignment="1" pref="772" max="32767" attributes="0"/>
                                   </Group>
                                 </DimensionLayout>
                               </Layout>
@@ -1477,7 +1562,7 @@
                                                   <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
                                                   <EmptySpace max="-2" attributes="0"/>
                                                   <Component id="jButton18" min="-2" max="-2" attributes="0"/>
-                                                  <EmptySpace pref="273" max="32767" attributes="0"/>
+                                                  <EmptySpace pref="270" max="32767" attributes="0"/>
                                               </Group>
                                           </Group>
                                         </DimensionLayout>
@@ -1797,7 +1882,7 @@
                                                   <Component id="jLabel1" min="-2" pref="23" max="-2" attributes="0"/>
                                                   <EmptySpace max="-2" attributes="0"/>
                                                   <Component id="jButton2" min="-2" max="-2" attributes="0"/>
-                                                  <EmptySpace pref="305" max="32767" attributes="0"/>
+                                                  <EmptySpace pref="342" max="32767" attributes="0"/>
                                               </Group>
                                           </Group>
                                         </DimensionLayout>

--- a/src/com/sfc/sf2/battle/gui/MainEditor.form
+++ b/src/com/sfc/sf2/battle/gui/MainEditor.form
@@ -1321,7 +1321,7 @@
                                               <Group type="102" alignment="1" attributes="0">
                                                   <Component id="jLabel23" min="-2" max="-2" attributes="0"/>
                                                   <EmptySpace max="-2" attributes="0"/>
-                                                  <Component id="jTextField21" pref="86" max="32767" attributes="0"/>
+                                                  <Component id="jTextField21" pref="0" max="32767" attributes="0"/>
                                                   <EmptySpace max="-2" attributes="0"/>
                                                   <Component id="jButton28" min="-2" max="-2" attributes="0"/>
                                               </Group>
@@ -1349,7 +1349,7 @@
                                               <Group type="102" alignment="0" attributes="0">
                                                   <Component id="jLabel25" min="-2" max="-2" attributes="0"/>
                                                   <EmptySpace max="-2" attributes="0"/>
-                                                  <Component id="jTextField23" pref="70" max="32767" attributes="0"/>
+                                                  <Component id="jTextField23" max="32767" attributes="0"/>
                                                   <EmptySpace max="-2" attributes="0"/>
                                                   <Component id="jButton30" min="-2" max="-2" attributes="0"/>
                                               </Group>
@@ -1654,7 +1654,7 @@
                                         </Component>
                                         <Component class="javax.swing.JTextField" name="jTextField25">
                                           <Properties>
-                                            <Property name="text" type="java.lang.String" value=".\u005centries\u005cbattle01\u005cspriteset.bin" containsInvalidXMLChars="true"/>
+                                            <Property name="text" type="java.lang.String" value=".\u005cspritesets\u005cspriteset01.asm" containsInvalidXMLChars="true"/>
                                           </Properties>
                                           <Events>
                                             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextField25ActionPerformed"/>

--- a/src/com/sfc/sf2/battle/gui/MainEditor.java
+++ b/src/com/sfc/sf2/battle/gui/MainEditor.java
@@ -7,6 +7,7 @@ package com.sfc.sf2.battle.gui;
 
 import com.sfc.sf2.battle.Battle;
 import com.sfc.sf2.battle.BattleManager;
+import com.sfc.sf2.battle.EnemyData;
 import com.sfc.sf2.battle.mapcoords.gui.BattleMapCoordsTableModel;
 import com.sfc.sf2.map.layout.MapLayoutManager;
 import static com.sun.org.apache.xalan.internal.lib.ExsltDynamic.map;
@@ -1700,8 +1701,6 @@ public class MainEditor extends javax.swing.JFrame {
         battlePanel.setBattle(battle);
         battlePanel.setMapLayout(mapLayoutManager.getLayout());
         battlePanel.setBlockset(mapLayoutManager.getBlockset());
-        battlePanel.setMapsprites(battleManager.getMapsprites());
-        battlePanel.setEnemySpriteIds(battleManager.getEnemySpriteIds());
         battlePanel.setDrawExplorationFlags(jCheckBox1.isSelected());
         battlePanel.setDrawGrid(jCheckBox2.isSelected());
         battlePanel.setDrawTerrain(jCheckBox3.isSelected());
@@ -1737,10 +1736,13 @@ public class MainEditor extends javax.swing.JFrame {
                 }
             }
         });    
+        
+        EnemyData[] enemyData = battleManager.getEnemyData();
+        
         battlePanel.setAlliesTable(allyTableModel);
         jPanel21.validate();
         jPanel21.repaint();
-        enemyTableModel = new EnemyPropertiesTableModel(battle, battlePanel);
+        enemyTableModel = new EnemyPropertiesTableModel(battle, battlePanel, enemyData);
         jTable3.setModel(enemyTableModel);
         jTable3.getSelectionModel().addListSelectionListener(new ListSelectionListener(){
             private int selectedRow = -1;

--- a/src/com/sfc/sf2/battle/gui/MainEditor.java
+++ b/src/com/sfc/sf2/battle/gui/MainEditor.java
@@ -7,7 +7,9 @@ package com.sfc.sf2.battle.gui;
 
 import com.sfc.sf2.battle.Battle;
 import com.sfc.sf2.battle.BattleManager;
+import com.sfc.sf2.battle.Enemy;
 import com.sfc.sf2.battle.EnemyData;
+import com.sfc.sf2.battle.EnemyEnums;
 import com.sfc.sf2.battle.mapcoords.gui.BattleMapCoordsTableModel;
 import com.sfc.sf2.map.layout.MapLayoutManager;
 import static com.sun.org.apache.xalan.internal.lib.ExsltDynamic.map;
@@ -22,6 +24,8 @@ import java.nio.file.Paths;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.ComboBoxModel;
+import javax.swing.DefaultComboBoxModel;
 import javax.swing.JFileChooser;
 import javax.swing.JTextArea;
 import javax.swing.event.ListSelectionEvent;
@@ -135,27 +139,30 @@ public class MainEditor extends javax.swing.JFrame {
         jButton5 = new javax.swing.JButton();
         jPanel17 = new javax.swing.JPanel();
         jLabel16 = new javax.swing.JLabel();
-        jSpinner12 = new javax.swing.JSpinner();
         jLabel17 = new javax.swing.JLabel();
-        jSpinner13 = new javax.swing.JSpinner();
-        jSpinner14 = new javax.swing.JSpinner();
+        jSpinner_X = new javax.swing.JSpinner();
+        jSpinner_Y = new javax.swing.JSpinner();
         jLabel18 = new javax.swing.JLabel();
         jLabel19 = new javax.swing.JLabel();
-        jSpinner15 = new javax.swing.JSpinner();
-        jLabel34 = new javax.swing.JLabel();
-        jSpinner16 = new javax.swing.JSpinner();
-        jLabel36 = new javax.swing.JLabel();
-        jSpinner18 = new javax.swing.JSpinner();
-        jLabel37 = new javax.swing.JLabel();
-        jSpinner19 = new javax.swing.JSpinner();
-        jLabel35 = new javax.swing.JLabel();
-        jSpinner17 = new javax.swing.JSpinner();
-        jLabel38 = new javax.swing.JLabel();
-        jSpinner20 = new javax.swing.JSpinner();
-        jLabel39 = new javax.swing.JLabel();
-        jSpinner21 = new javax.swing.JSpinner();
+        jComboBox_Name = new javax.swing.JComboBox<>();
+        jComboBox_AI = new javax.swing.JComboBox<>();
+        jComboBox_Spawn = new javax.swing.JComboBox<>();
         jLabel40 = new javax.swing.JLabel();
-        jSpinner22 = new javax.swing.JSpinner();
+        jLabel34 = new javax.swing.JLabel();
+        jComboBox_Items = new javax.swing.JComboBox<>();
+        jLabel36 = new javax.swing.JLabel();
+        jComboBox_Order1 = new javax.swing.JComboBox<>();
+        jLabel37 = new javax.swing.JLabel();
+        jSpinner_Trigger1 = new javax.swing.JSpinner();
+        jLabel35 = new javax.swing.JLabel();
+        jComboBox_Order2 = new javax.swing.JComboBox<>();
+        jLabel41 = new javax.swing.JLabel();
+        jSpinner_OrderTarget1 = new javax.swing.JSpinner();
+        jLabel42 = new javax.swing.JLabel();
+        jSpinner_OrderTarget2 = new javax.swing.JSpinner();
+        jLabel38 = new javax.swing.JLabel();
+        jSpinner_Trigger2 = new javax.swing.JSpinner();
+        jTextField_ItemFlags = new javax.swing.JTextField();
         jPanel26 = new javax.swing.JPanel();
         jScrollPane9 = new javax.swing.JScrollPane();
         jTable4 = new javax.swing.JTable();
@@ -247,11 +254,11 @@ public class MainEditor extends javax.swing.JFrame {
         jPanel2.setLayout(jPanel2Layout);
         jPanel2Layout.setHorizontalGroup(
             jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 858, Short.MAX_VALUE)
+            .addGap(0, 824, Short.MAX_VALUE)
         );
         jPanel2Layout.setVerticalGroup(
             jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 715, Short.MAX_VALUE)
+            .addGap(0, 739, Short.MAX_VALUE)
         );
 
         jScrollPane2.setViewportView(jPanel2);
@@ -260,18 +267,19 @@ public class MainEditor extends javax.swing.JFrame {
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jScrollPane2, javax.swing.GroupLayout.DEFAULT_SIZE, 436, Short.MAX_VALUE)
+            .addComponent(jScrollPane2, javax.swing.GroupLayout.DEFAULT_SIZE, 512, Short.MAX_VALUE)
         );
         jPanel1Layout.setVerticalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jScrollPane2, javax.swing.GroupLayout.DEFAULT_SIZE, 694, Short.MAX_VALUE)
+            .addComponent(jScrollPane2, javax.swing.GroupLayout.DEFAULT_SIZE, 749, Short.MAX_VALUE)
         );
 
         javax.swing.GroupLayout jPanel10Layout = new javax.swing.GroupLayout(jPanel10);
         jPanel10.setLayout(jPanel10Layout);
         jPanel10Layout.setHorizontalGroup(
             jPanel10Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel10Layout.createSequentialGroup()
+            .addGroup(jPanel10Layout.createSequentialGroup()
+                .addContainerGap()
                 .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGap(4, 4, 4))
         );
@@ -423,7 +431,7 @@ public class MainEditor extends javax.swing.JFrame {
                     .addComponent(jLabel9)
                     .addComponent(jSpinner8, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jLabel11))
-                .addContainerGap(446, Short.MAX_VALUE))
+                .addContainerGap(470, Short.MAX_VALUE))
         );
 
         jTabbedPane2.addTab("Map Coords", jPanel4);
@@ -554,7 +562,7 @@ public class MainEditor extends javax.swing.JFrame {
                 .addGroup(jPanel18Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jButton1)
                     .addComponent(jButton3))
-                .addContainerGap(19, Short.MAX_VALUE))
+                .addContainerGap(51, Short.MAX_VALUE))
         );
 
         javax.swing.GroupLayout jPanel24Layout = new javax.swing.GroupLayout(jPanel24);
@@ -611,31 +619,21 @@ public class MainEditor extends javax.swing.JFrame {
 
         jPanel17.setBorder(javax.swing.BorderFactory.createTitledBorder("Selected Enemy :"));
 
-        jLabel16.setText("Index :");
-
-        jSpinner12.setModel(new javax.swing.SpinnerNumberModel(1, 1, 12, 1));
-        jSpinner12.setEnabled(false);
-        jSpinner12.addChangeListener(new javax.swing.event.ChangeListener() {
-            public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner12StateChanged(evt);
-            }
-        });
+        jLabel16.setText("Name :");
 
         jLabel17.setText("X :");
 
-        jSpinner13.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
-        jSpinner13.setEnabled(false);
-        jSpinner13.addChangeListener(new javax.swing.event.ChangeListener() {
+        jSpinner_X.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
+        jSpinner_X.addChangeListener(new javax.swing.event.ChangeListener() {
             public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner13StateChanged(evt);
+                jSpinner_XStateChanged(evt);
             }
         });
 
-        jSpinner14.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
-        jSpinner14.setEnabled(false);
-        jSpinner14.addChangeListener(new javax.swing.event.ChangeListener() {
+        jSpinner_Y.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
+        jSpinner_Y.addChangeListener(new javax.swing.event.ChangeListener() {
             public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner14StateChanged(evt);
+                jSpinner_YStateChanged(evt);
             }
         });
 
@@ -643,81 +641,96 @@ public class MainEditor extends javax.swing.JFrame {
 
         jLabel19.setText("AI :");
 
-        jSpinner15.setModel(new javax.swing.SpinnerNumberModel(1, 1, 12, 1));
-        jSpinner15.setEnabled(false);
-        jSpinner15.addChangeListener(new javax.swing.event.ChangeListener() {
-            public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner15StateChanged(evt);
+        jComboBox_Name.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
+        jComboBox_Name.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                jComboBox_NameItemStateChanged(evt);
             }
         });
+
+        jComboBox_AI.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
+        jComboBox_AI.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                jComboBox_AIItemStateChanged(evt);
+            }
+        });
+
+        jComboBox_Spawn.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
+        jComboBox_Spawn.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                jComboBox_SpawnItemStateChanged(evt);
+            }
+        });
+
+        jLabel40.setText("Spawn :");
 
         jLabel34.setText("Item :");
 
-        jSpinner16.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
-        jSpinner16.setEnabled(false);
-        jSpinner16.addChangeListener(new javax.swing.event.ChangeListener() {
-            public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner16StateChanged(evt);
+        jComboBox_Items.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
+        jComboBox_Items.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                jComboBox_ItemsItemStateChanged(evt);
             }
         });
 
-        jLabel36.setText("Order 1 :");
+        jLabel36.setText("Move Order 1 :");
 
-        jSpinner18.setModel(new javax.swing.SpinnerNumberModel(1, 1, 12, 1));
-        jSpinner18.setEnabled(false);
-        jSpinner18.addChangeListener(new javax.swing.event.ChangeListener() {
-            public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner18StateChanged(evt);
+        jComboBox_Order1.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
+        jComboBox_Order1.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                jComboBox_Order1ItemStateChanged(evt);
             }
         });
 
-        jLabel37.setText("Trig. Region :");
+        jLabel37.setText("Trig. Reg. 1 :");
 
-        jSpinner19.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
-        jSpinner19.setEnabled(false);
-        jSpinner19.addChangeListener(new javax.swing.event.ChangeListener() {
+        jSpinner_Trigger1.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
+        jSpinner_Trigger1.addChangeListener(new javax.swing.event.ChangeListener() {
             public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner19StateChanged(evt);
+                jSpinner_Trigger1StateChanged(evt);
             }
         });
 
-        jLabel35.setText("Byte 8 :");
+        jLabel35.setText("Move Order 2 :");
 
-        jSpinner17.setModel(new javax.swing.SpinnerNumberModel(1, 1, 12, 1));
-        jSpinner17.setEnabled(false);
-        jSpinner17.addChangeListener(new javax.swing.event.ChangeListener() {
-            public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner17StateChanged(evt);
+        jComboBox_Order2.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
+        jComboBox_Order2.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                jComboBox_Order2ItemStateChanged(evt);
             }
         });
 
-        jLabel38.setText("Byte 9 :");
+        jLabel41.setText("Target :");
 
-        jSpinner20.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
-        jSpinner20.setEnabled(false);
-        jSpinner20.addChangeListener(new javax.swing.event.ChangeListener() {
+        jSpinner_OrderTarget1.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
+        jSpinner_OrderTarget1.addChangeListener(new javax.swing.event.ChangeListener() {
             public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner20StateChanged(evt);
+                jSpinner_OrderTarget1StateChanged(evt);
             }
         });
 
-        jLabel39.setText("Byte 10 :");
+        jLabel42.setText("Target :");
 
-        jSpinner21.setModel(new javax.swing.SpinnerNumberModel(1, 1, 12, 1));
-        jSpinner21.setEnabled(false);
-        jSpinner21.addChangeListener(new javax.swing.event.ChangeListener() {
+        jSpinner_OrderTarget2.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
+        jSpinner_OrderTarget2.addChangeListener(new javax.swing.event.ChangeListener() {
             public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner21StateChanged(evt);
+                jSpinner_OrderTarget2StateChanged(evt);
             }
         });
 
-        jLabel40.setText("Spawn param :");
+        jLabel38.setText("Trig. Reg. 2 :");
 
-        jSpinner22.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
-        jSpinner22.setEnabled(false);
-        jSpinner22.addChangeListener(new javax.swing.event.ChangeListener() {
+        jSpinner_Trigger2.setModel(new javax.swing.SpinnerNumberModel(0, 0, 63, 1));
+        jSpinner_Trigger2.addChangeListener(new javax.swing.event.ChangeListener() {
             public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                jSpinner22StateChanged(evt);
+                jSpinner_Trigger2StateChanged(evt);
+            }
+        });
+
+        jTextField_ItemFlags.setText("flags");
+        jTextField_ItemFlags.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jTextField_ItemFlagsActionPerformed(evt);
             }
         });
 
@@ -729,90 +742,108 @@ public class MainEditor extends javax.swing.JFrame {
                 .addContainerGap()
                 .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(jPanel17Layout.createSequentialGroup()
-                        .addComponent(jLabel39)
+                        .addComponent(jLabel35)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jSpinner21, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addGap(24, 24, 24)
-                        .addComponent(jLabel40)
+                        .addComponent(jComboBox_Order2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(jPanel17Layout.createSequentialGroup()
+                        .addComponent(jLabel36)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jSpinner22, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addComponent(jComboBox_Order1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
+                        .addGroup(javax.swing.GroupLayout.Alignment.LEADING, jPanel17Layout.createSequentialGroup()
+                            .addComponent(jLabel38, javax.swing.GroupLayout.PREFERRED_SIZE, 72, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                            .addComponent(jSpinner_Trigger2, javax.swing.GroupLayout.PREFERRED_SIZE, 1, Short.MAX_VALUE))
+                        .addGroup(javax.swing.GroupLayout.Alignment.LEADING, jPanel17Layout.createSequentialGroup()
+                            .addComponent(jLabel37)
+                            .addGap(14, 14, 14)
+                            .addComponent(jSpinner_Trigger1, javax.swing.GroupLayout.PREFERRED_SIZE, 55, javax.swing.GroupLayout.PREFERRED_SIZE)))
                     .addGroup(jPanel17Layout.createSequentialGroup()
                         .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                                .addGroup(jPanel17Layout.createSequentialGroup()
-                                    .addComponent(jLabel16)
-                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                    .addComponent(jSpinner12, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                .addGroup(jPanel17Layout.createSequentialGroup()
-                                    .addComponent(jLabel35)
-                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                                    .addComponent(jSpinner17, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                    .addComponent(jLabel38))
-                                .addGroup(jPanel17Layout.createSequentialGroup()
-                                    .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                        .addGroup(jPanel17Layout.createSequentialGroup()
-                                            .addComponent(jLabel19)
-                                            .addGap(30, 30, 30)
-                                            .addComponent(jSpinner15, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                        .addGroup(jPanel17Layout.createSequentialGroup()
-                                            .addComponent(jLabel36)
-                                            .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                            .addComponent(jSpinner18, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE)))
-                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 32, Short.MAX_VALUE)
-                                    .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                        .addComponent(jLabel37, javax.swing.GroupLayout.Alignment.TRAILING)
-                                        .addComponent(jLabel34, javax.swing.GroupLayout.Alignment.TRAILING)
-                                        .addComponent(jLabel18, javax.swing.GroupLayout.Alignment.TRAILING))))
-                            .addGroup(jPanel17Layout.createSequentialGroup()
-                                .addComponent(jLabel17)
-                                .addGap(35, 35, 35)
-                                .addComponent(jSpinner13, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                            .addComponent(jLabel19)
+                            .addComponent(jLabel34))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jSpinner20, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(jSpinner19, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(jSpinner16, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(jSpinner14, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE))))
-                .addGap(0, 26, Short.MAX_VALUE))
+                        .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                            .addGroup(jPanel17Layout.createSequentialGroup()
+                                .addComponent(jComboBox_AI, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                .addComponent(jLabel40, javax.swing.GroupLayout.PREFERRED_SIZE, 48, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addGap(4, 4, 4)
+                                .addComponent(jComboBox_Spawn, javax.swing.GroupLayout.PREFERRED_SIZE, 99, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
+                                .addGroup(jPanel17Layout.createSequentialGroup()
+                                    .addGap(130, 130, 130)
+                                    .addComponent(jLabel41, javax.swing.GroupLayout.PREFERRED_SIZE, 48, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                    .addComponent(jSpinner_OrderTarget1, javax.swing.GroupLayout.PREFERRED_SIZE, 55, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                .addGroup(jPanel17Layout.createSequentialGroup()
+                                    .addComponent(jComboBox_Items, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                    .addComponent(jTextField_ItemFlags, javax.swing.GroupLayout.PREFERRED_SIZE, 149, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                .addGroup(jPanel17Layout.createSequentialGroup()
+                                    .addComponent(jLabel42, javax.swing.GroupLayout.PREFERRED_SIZE, 48, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                    .addComponent(jSpinner_OrderTarget2, javax.swing.GroupLayout.PREFERRED_SIZE, 55, javax.swing.GroupLayout.PREFERRED_SIZE)))))
+                    .addGroup(jPanel17Layout.createSequentialGroup()
+                        .addComponent(jLabel16)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jComboBox_Name, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jLabel17)
+                        .addGap(4, 4, 4)
+                        .addComponent(jSpinner_X, javax.swing.GroupLayout.PREFERRED_SIZE, 46, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGap(12, 12, 12)
+                        .addComponent(jLabel18)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jSpinner_Y, javax.swing.GroupLayout.PREFERRED_SIZE, 49, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         jPanel17Layout.setVerticalGroup(
             jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jPanel17Layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jSpinner12, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel16))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 27, Short.MAX_VALUE)
-                .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jSpinner13, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel16)
+                    .addComponent(jComboBox_Name, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jSpinner_X, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jLabel17)
                     .addComponent(jLabel18)
-                    .addComponent(jSpinner14, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addComponent(jSpinner_Y, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel19)
+                    .addComponent(jComboBox_AI, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel40)
+                    .addComponent(jComboBox_Spawn, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jSpinner15, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel19)
-                    .addComponent(jSpinner16, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel34))
+                    .addComponent(jLabel34)
+                    .addComponent(jComboBox_Items, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jTextField_ItemFlags, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(jPanel17Layout.createSequentialGroup()
+                        .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                            .addComponent(jLabel36)
+                            .addComponent(jComboBox_Order1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                            .addComponent(jLabel37)
+                            .addComponent(jSpinner_Trigger1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                            .addComponent(jLabel35)
+                            .addComponent(jComboBox_Order2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                                .addComponent(jLabel42)
+                                .addComponent(jSpinner_OrderTarget2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                    .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                        .addComponent(jLabel41)
+                        .addComponent(jSpinner_OrderTarget1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jSpinner18, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel36)
-                    .addComponent(jSpinner19, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel37))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jSpinner17, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel35)
-                    .addComponent(jSpinner20, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel38))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jSpinner21, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel39)
-                    .addComponent(jSpinner22, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel40))
+                    .addComponent(jLabel38)
+                    .addComponent(jSpinner_Trigger2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addContainerGap())
         );
 
@@ -827,7 +858,7 @@ public class MainEditor extends javax.swing.JFrame {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jButton5)
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-            .addComponent(jPanel17, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addComponent(jPanel17, javax.swing.GroupLayout.PREFERRED_SIZE, 285, Short.MAX_VALUE)
         );
         jPanel25Layout.setVerticalGroup(
             jPanel25Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -873,7 +904,7 @@ public class MainEditor extends javax.swing.JFrame {
         );
         jPanel26Layout.setVerticalGroup(
             jPanel26Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jScrollPane9, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 527, Short.MAX_VALUE)
+            .addComponent(jScrollPane9, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 563, Short.MAX_VALUE)
         );
 
         jTabbedPane3.addTab("AI Regions", jPanel26);
@@ -907,7 +938,7 @@ public class MainEditor extends javax.swing.JFrame {
         );
         jPanel31Layout.setVerticalGroup(
             jPanel31Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(jScrollPane14, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 527, Short.MAX_VALUE)
+            .addComponent(jScrollPane14, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 563, Short.MAX_VALUE)
         );
 
         jTabbedPane3.addTab("AI Points", jPanel31);
@@ -1336,7 +1367,7 @@ public class MainEditor extends javax.swing.JFrame {
                     .addComponent(jLabel2)
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                     .addComponent(jButton18)
-                    .addContainerGap(273, Short.MAX_VALUE))
+                    .addContainerGap(270, Short.MAX_VALUE))
             );
 
             jTabbedPane1.addTab("Import", jPanel3);
@@ -1451,7 +1482,7 @@ public class MainEditor extends javax.swing.JFrame {
                     .addComponent(jLabel1, javax.swing.GroupLayout.PREFERRED_SIZE, 23, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                     .addComponent(jButton2)
-                    .addContainerGap(305, Short.MAX_VALUE))
+                    .addContainerGap(342, Short.MAX_VALUE))
             );
 
             jTabbedPane1.addTab("Export", jPanel5);
@@ -1464,7 +1495,7 @@ public class MainEditor extends javax.swing.JFrame {
             );
             jPanel9Layout.setVerticalGroup(
                 jPanel9Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addComponent(jTabbedPane1, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 715, Short.MAX_VALUE)
+                .addComponent(jTabbedPane1, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 772, Short.MAX_VALUE)
             );
 
             jSplitPane4.setLeftComponent(jPanel9);
@@ -1553,7 +1584,7 @@ public class MainEditor extends javax.swing.JFrame {
             jPanel13.setLayout(jPanel13Layout);
             jPanel13Layout.setHorizontalGroup(
                 jPanel13Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addComponent(jSplitPane1)
+                .addComponent(jSplitPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 1077, Short.MAX_VALUE)
             );
             jPanel13Layout.setVerticalGroup(
                 jPanel13Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -1571,7 +1602,7 @@ public class MainEditor extends javax.swing.JFrame {
                 .addComponent(jPanel13, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             );
 
-            setSize(new java.awt.Dimension(1016, 838));
+            setSize(new java.awt.Dimension(1093, 838));
             setLocationRelativeTo(null);
         }// </editor-fold>//GEN-END:initComponents
 
@@ -1722,6 +1753,7 @@ public class MainEditor extends javax.swing.JFrame {
                 if(selectedRow!=jTable3.getSelectedRow()){
                     selectedRow = jTable3.getSelectedRow();
                     battlePanel.setSelectedEnemy(selectedRow);
+                    UpdateEnemyControls(selectedRow);
                     battlePanel.updateSpriteDisplay();
                     jPanel2.revalidate();
                     jPanel2.repaint();
@@ -1770,8 +1802,66 @@ public class MainEditor extends javax.swing.JFrame {
         jPanel26.validate();
         jPanel26.repaint();
         battlePanel.setTitledPanel(jPanel1);
+        
+        EnemyEnums enemyEnums = battleManager.getEnemyEnums();
+        jComboBox_Name.setModel(new DefaultComboBoxModel<>(enemyEnums.getEnemies().keySet().toArray(new String[enemyEnums.getEnemies().size()])));
+        jComboBox_AI.setModel(new DefaultComboBoxModel<>(enemyEnums.getCommandSets().keySet().toArray(new String[enemyEnums.getCommandSets().size()])));
+        jComboBox_Spawn.setModel(new DefaultComboBoxModel<>(enemyEnums.getSpawnParams().keySet().toArray(new String[enemyEnums.getSpawnParams().size()])));
+        jComboBox_Order1.setModel(new DefaultComboBoxModel<>(enemyEnums.getOrders().keySet().toArray(new String[enemyEnums.getOrders().size()])));
+        jComboBox_Order2.setModel(new DefaultComboBoxModel<>(enemyEnums.getOrders().keySet().toArray(new String[enemyEnums.getOrders().size()])));
+        jComboBox_Items.setModel(new DefaultComboBoxModel<>(enemyEnums.getItems().keySet().toArray(new String[enemyEnums.getItems().size()])));
+        
+        jPanel17.invalidate();
+        jPanel17.repaint();
     }//GEN-LAST:event_jButton18ActionPerformed
 
+    private void UpdateEnemyControls(int selectedRow)
+    {
+        boolean enabled = selectedRow >= 0;
+        jComboBox_Name.setEnabled(enabled);
+        jSpinner_X.setEnabled(enabled);
+        jSpinner_Y.setEnabled(enabled);
+        jComboBox_AI.setEnabled(enabled);
+        jComboBox_Spawn.setEnabled(enabled);
+        jSpinner_Trigger1.setEnabled(enabled);
+        jSpinner_Trigger2.setEnabled(enabled);
+        jComboBox_Order1.setEnabled(enabled);
+        jComboBox_Order2.setEnabled(enabled);
+        jSpinner_OrderTarget1.setEnabled(enabled);
+        jSpinner_OrderTarget2.setEnabled(enabled);
+        jComboBox_Items.setEnabled(enabled);
+        jTextField_ItemFlags.setEnabled(enabled);
+              
+        if (selectedRow != -1){
+            Enemy enemy = (selectedRow == -1) ? null : battle.getSpriteset().getEnemies()[selectedRow];
+            if (enemy != null) {
+                jComboBox_Name.setSelectedItem(enemy.getEnemyData().getName());
+                jSpinner_X.setValue(enemy.getX());
+                jSpinner_Y.setValue(enemy.getY());
+                jComboBox_AI.setSelectedItem(enemy.getAi());
+                jComboBox_Spawn.setSelectedItem(enemy.getSpawnParams());
+                jSpinner_Trigger1.setValue(enemy.getTriggerRegion1());
+                jSpinner_Trigger2.setValue(enemy.getTriggerRegion2());
+                
+                String[] order = enemy.getMoveOrder1().split("\\|");
+                jComboBox_Order1.setSelectedItem(order[0]);
+                jSpinner_OrderTarget1.setValue(order.length > 1 ? Integer.parseInt(order[1]) : 0);
+                order = enemy.getMoveOrder2().split("\\|");
+                jComboBox_Order2.setSelectedItem(order[0]);
+                jSpinner_OrderTarget2.setValue(order.length > 1 ? Integer.parseInt(order[1]) : 0);
+                
+                String item = enemy.getItem();
+                String flags = "";
+                if (item.contains("|")) {
+                    flags = item.substring(item.indexOf("|")+1);
+                    item = item.substring(0, item.indexOf("|"));
+                }
+                jComboBox_Items.setSelectedItem(item);
+                jTextField_ItemFlags.setText(flags);
+            }
+        }
+    }
+    
     private void jButton26ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton26ActionPerformed
         int returnVal = jFileChooser1.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
@@ -2044,49 +2134,17 @@ public class MainEditor extends javax.swing.JFrame {
         }
     }//GEN-LAST:event_jButton37ActionPerformed
 
-    private void jSpinner19StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner19StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner19StateChanged
+    private void jSpinner_Trigger1StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner_Trigger1StateChanged
+        OnEnemyDataChanged((int)jSpinner_Y.getValue(), 6);
+    }//GEN-LAST:event_jSpinner_Trigger1StateChanged
 
-    private void jSpinner18StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner18StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner18StateChanged
+    private void jSpinner_YStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner_YStateChanged
+        OnEnemyDataChanged((int)jSpinner_Y.getValue(), 2);
+    }//GEN-LAST:event_jSpinner_YStateChanged
 
-    private void jSpinner16StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner16StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner16StateChanged
-
-    private void jSpinner15StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner15StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner15StateChanged
-
-    private void jSpinner14StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner14StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner14StateChanged
-
-    private void jSpinner13StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner13StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner13StateChanged
-
-    private void jSpinner12StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner12StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner12StateChanged
-
-    private void jSpinner17StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner17StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner17StateChanged
-
-    private void jSpinner20StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner20StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner20StateChanged
-
-    private void jSpinner21StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner21StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner21StateChanged
-
-    private void jSpinner22StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner22StateChanged
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jSpinner22StateChanged
+    private void jSpinner_Trigger2StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner_Trigger2StateChanged
+        OnEnemyDataChanged((int)jSpinner_Y.getValue(), 8);
+    }//GEN-LAST:event_jSpinner_Trigger2StateChanged
 
     private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
         allyTableModel.addRow();
@@ -2121,6 +2179,65 @@ public class MainEditor extends javax.swing.JFrame {
         battlePanel.setApplicableTerrainValue(newApplicableTerrainValue);
     }//GEN-LAST:event_jSpinner9StateChanged
 
+    private void jSpinner_OrderTarget1StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner_OrderTarget1StateChanged
+        OnEnemyOrderChanged((String)jComboBox_Order1.getSelectedItem(), (int)jSpinner_OrderTarget1.getValue(), true);
+    }//GEN-LAST:event_jSpinner_OrderTarget1StateChanged
+
+    private void jSpinner_OrderTarget2StateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner_OrderTarget2StateChanged
+        OnEnemyOrderChanged((String)jComboBox_Order2.getSelectedItem(), (int)jSpinner_OrderTarget2.getValue(), false);
+    }//GEN-LAST:event_jSpinner_OrderTarget2StateChanged
+
+    private void jTextField_ItemFlagsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField_ItemFlagsActionPerformed
+        OnEnemyItemChanged((String)jComboBox_Items.getSelectedItem(), (String)jTextField_ItemFlags.getText());
+    }//GEN-LAST:event_jTextField_ItemFlagsActionPerformed
+
+    private void jComboBox_NameItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_jComboBox_NameItemStateChanged
+        OnEnemyDataChanged((String)evt.getItem(), 0);
+    }//GEN-LAST:event_jComboBox_NameItemStateChanged
+
+    private void jSpinner_XStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_jSpinner_XStateChanged
+        OnEnemyDataChanged((int)jSpinner_X.getValue(), 1);
+    }//GEN-LAST:event_jSpinner_XStateChanged
+
+    private void jComboBox_AIItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_jComboBox_AIItemStateChanged
+        OnEnemyDataChanged((String)evt.getItem(), 3);
+    }//GEN-LAST:event_jComboBox_AIItemStateChanged
+
+    private void jComboBox_SpawnItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_jComboBox_SpawnItemStateChanged
+        OnEnemyDataChanged((String)evt.getItem(), 10);
+    }//GEN-LAST:event_jComboBox_SpawnItemStateChanged
+
+    private void jComboBox_ItemsItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_jComboBox_ItemsItemStateChanged
+        OnEnemyItemChanged((String)evt.getItem(), jTextField_ItemFlags.getSelectedText());
+    }//GEN-LAST:event_jComboBox_ItemsItemStateChanged
+
+    private void jComboBox_Order1ItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_jComboBox_Order1ItemStateChanged
+        OnEnemyOrderChanged((String)evt.getItem(), (int)jSpinner_OrderTarget1.getValue(), true);
+    }//GEN-LAST:event_jComboBox_Order1ItemStateChanged
+
+    private void jComboBox_Order2ItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_jComboBox_Order2ItemStateChanged
+        OnEnemyOrderChanged((String)evt.getItem(), (int)jSpinner_OrderTarget2.getValue(), false);
+    }//GEN-LAST:event_jComboBox_Order2ItemStateChanged
+
+    private void OnEnemyDataChanged(Object data, int column){
+        int selectRow = jTable3.getSelectedRow();
+        if (selectRow == -1)
+            return;
+        
+        jTable3.setValueAt(data, selectRow, column);
+    }
+
+    private void OnEnemyItemChanged(String item, String flags){
+        if (flags == null || flags.length() == 0)
+            OnEnemyDataChanged(item, 4);
+        else
+            OnEnemyDataChanged(item+"|"+flags, 4);
+    }
+
+    private void OnEnemyOrderChanged(String order, int target, boolean order1){
+        OnEnemyDataChanged(order+"|"+target, order1 ? 5 : 7);
+    }
+    
     /**
      * @param args the command line arguments
      */
@@ -2189,6 +2306,12 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JCheckBox jCheckBox3;
     private javax.swing.JCheckBox jCheckBox4;
     private javax.swing.JComboBox<String> jComboBox1;
+    private javax.swing.JComboBox<String> jComboBox_AI;
+    private javax.swing.JComboBox<String> jComboBox_Items;
+    private javax.swing.JComboBox<String> jComboBox_Name;
+    private javax.swing.JComboBox<String> jComboBox_Order1;
+    private javax.swing.JComboBox<String> jComboBox_Order2;
+    private javax.swing.JComboBox<String> jComboBox_Spawn;
     private javax.swing.JFileChooser jFileChooser1;
     private javax.swing.JFileChooser jFileChooser2;
     private javax.swing.JLabel jLabel1;
@@ -2220,9 +2343,10 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JLabel jLabel36;
     private javax.swing.JLabel jLabel37;
     private javax.swing.JLabel jLabel38;
-    private javax.swing.JLabel jLabel39;
     private javax.swing.JLabel jLabel4;
     private javax.swing.JLabel jLabel40;
+    private javax.swing.JLabel jLabel41;
+    private javax.swing.JLabel jLabel42;
     private javax.swing.JLabel jLabel5;
     private javax.swing.JLabel jLabel6;
     private javax.swing.JLabel jLabel7;
@@ -2259,18 +2383,7 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JScrollPane jScrollPane8;
     private javax.swing.JScrollPane jScrollPane9;
     private javax.swing.JSpinner jSpinner1;
-    private javax.swing.JSpinner jSpinner12;
-    private javax.swing.JSpinner jSpinner13;
-    private javax.swing.JSpinner jSpinner14;
-    private javax.swing.JSpinner jSpinner15;
-    private javax.swing.JSpinner jSpinner16;
-    private javax.swing.JSpinner jSpinner17;
-    private javax.swing.JSpinner jSpinner18;
-    private javax.swing.JSpinner jSpinner19;
     private javax.swing.JSpinner jSpinner2;
-    private javax.swing.JSpinner jSpinner20;
-    private javax.swing.JSpinner jSpinner21;
-    private javax.swing.JSpinner jSpinner22;
     private javax.swing.JSpinner jSpinner3;
     private javax.swing.JSpinner jSpinner4;
     private javax.swing.JSpinner jSpinner5;
@@ -2278,6 +2391,12 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JSpinner jSpinner7;
     private javax.swing.JSpinner jSpinner8;
     private javax.swing.JSpinner jSpinner9;
+    private javax.swing.JSpinner jSpinner_OrderTarget1;
+    private javax.swing.JSpinner jSpinner_OrderTarget2;
+    private javax.swing.JSpinner jSpinner_Trigger1;
+    private javax.swing.JSpinner jSpinner_Trigger2;
+    private javax.swing.JSpinner jSpinner_X;
+    private javax.swing.JSpinner jSpinner_Y;
     private javax.swing.JSplitPane jSplitPane1;
     private javax.swing.JSplitPane jSplitPane2;
     private javax.swing.JSplitPane jSplitPane3;
@@ -2305,6 +2424,7 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JTextField jTextField30;
     private javax.swing.JTextField jTextField31;
     private javax.swing.JTextField jTextField32;
+    private javax.swing.JTextField jTextField_ItemFlags;
     // End of variables declaration//GEN-END:variables
 
 

--- a/src/com/sfc/sf2/battle/gui/MainEditor.java
+++ b/src/com/sfc/sf2/battle/gui/MainEditor.java
@@ -1424,7 +1424,7 @@ public class MainEditor extends javax.swing.JFrame {
                 }
             });
 
-            jTextField28.setText(".\\entries\\battle01\\spriteset.bin");
+            jTextField28.setText(".\\spritesets\\spriteset01.asm");
             jTextField28.addActionListener(new java.awt.event.ActionListener() {
                 public void actionPerformed(java.awt.event.ActionEvent evt) {
                     jTextField28ActionPerformed(evt);

--- a/src/com/sfc/sf2/battle/gui/MainEditor.java
+++ b/src/com/sfc/sf2/battle/gui/MainEditor.java
@@ -197,9 +197,6 @@ public class MainEditor extends javax.swing.JFrame {
         jLabel27 = new javax.swing.JLabel();
         jTextField25 = new javax.swing.JTextField();
         jButton32 = new javax.swing.JButton();
-        jLabel31 = new javax.swing.JLabel();
-        jTextField29 = new javax.swing.JTextField();
-        jButton36 = new javax.swing.JButton();
         jLabel22 = new javax.swing.JLabel();
         jTextField30 = new javax.swing.JTextField();
         jButton27 = new javax.swing.JButton();
@@ -1154,22 +1151,6 @@ public class MainEditor extends javax.swing.JFrame {
                 }
             });
 
-            jLabel31.setText("Enemy sprites :");
-
-            jTextField29.setText("..\\stats\\enemies\\enemymapsprites.asm");
-            jTextField29.addActionListener(new java.awt.event.ActionListener() {
-                public void actionPerformed(java.awt.event.ActionEvent evt) {
-                    jTextField29ActionPerformed(evt);
-                }
-            });
-
-            jButton36.setText("File...");
-            jButton36.addActionListener(new java.awt.event.ActionListener() {
-                public void actionPerformed(java.awt.event.ActionEvent evt) {
-                    jButton36ActionPerformed(evt);
-                }
-            });
-
             jLabel22.setText("Mapsprite entries :");
 
             jTextField30.setText("..\\graphics\\mapsprites\\entries.asm");
@@ -1266,12 +1247,6 @@ public class MainEditor extends javax.swing.JFrame {
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                     .addComponent(jButton31))
                 .addGroup(jPanel3Layout.createSequentialGroup()
-                    .addComponent(jLabel31)
-                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                    .addComponent(jTextField29, javax.swing.GroupLayout.PREFERRED_SIZE, 1, Short.MAX_VALUE)
-                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                    .addComponent(jButton36))
-                .addGroup(jPanel3Layout.createSequentialGroup()
                     .addComponent(jLabel22)
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                     .addComponent(jTextField30, javax.swing.GroupLayout.PREFERRED_SIZE, 1, Short.MAX_VALUE)
@@ -1345,11 +1320,6 @@ public class MainEditor extends javax.swing.JFrame {
                         .addComponent(jButton37))
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                     .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                        .addComponent(jTextField29, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addComponent(jLabel31)
-                        .addComponent(jButton36))
-                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                    .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                         .addComponent(jSpinner4, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addComponent(jLabel10))
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -1366,7 +1336,7 @@ public class MainEditor extends javax.swing.JFrame {
                     .addComponent(jLabel2)
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                     .addComponent(jButton18)
-                    .addContainerGap(240, Short.MAX_VALUE))
+                    .addContainerGap(273, Short.MAX_VALUE))
             );
 
             jTabbedPane1.addTab("Import", jPanel3);
@@ -1676,12 +1646,11 @@ public class MainEditor extends javax.swing.JFrame {
         String basePalettePath = PATH_TEST_PREFIX+jTextField32.getText();
         String mapspriteEntriesPath = PATH_TEST_PREFIX+jTextField30.getText();
         String mapspriteEnumPath = PATH_TEST_PREFIX+jTextField31.getText();
-        String enemySpritesPath = PATH_TEST_PREFIX+jTextField29.getText();
         int battleIndex = (int)jSpinner4.getModel().getValue();
         String terrainPath = PATH_TEST_PREFIX+jTextField24.getText();
         String spritesetPath = PATH_TEST_PREFIX+jTextField25.getText();
         
-        battleManager.importDisassembly(mapPalettesPath, mapTilesetsPath, incbinPath, mapEntriesPath, mapCoordsPath, basePalettePath, mapspriteEntriesPath, mapspriteEnumPath, enemySpritesPath,
+        battleManager.importDisassembly(mapPalettesPath, mapTilesetsPath, incbinPath, mapEntriesPath, mapCoordsPath, basePalettePath, mapspriteEntriesPath, mapspriteEnumPath,
                                     battleIndex, terrainPath, spritesetPath);
 
         battle = battleManager.getBattle();
@@ -1926,22 +1895,6 @@ public class MainEditor extends javax.swing.JFrame {
     private void jTextField28ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField28ActionPerformed
         // TODO add your handling code here:
     }//GEN-LAST:event_jTextField28ActionPerformed
-
-    private void jTextField29ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField29ActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jTextField29ActionPerformed
-
-    private void jButton36ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton36ActionPerformed
-        int returnVal = jFileChooser1.showOpenDialog(this);
-        if (returnVal == JFileChooser.APPROVE_OPTION) {
-            File file = jFileChooser1.getSelectedFile();
-            /*Path basePath = Paths.get(jTextField24.getText()).toAbsolutePath();
-            Path filePath = Paths.get(file.getAbsolutePath());
-            Path relativePath = basePath.relativize(filePath);
-            jTextField19.setText(relativePath.toString());*/
-            jTextField29.setText(file.getAbsolutePath());
-        }
-    }//GEN-LAST:event_jButton36ActionPerformed
 
     private void jTextField30ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField30ActionPerformed
         // TODO add your handling code here:
@@ -2227,7 +2180,6 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JButton jButton33;
     private javax.swing.JButton jButton34;
     private javax.swing.JButton jButton35;
-    private javax.swing.JButton jButton36;
     private javax.swing.JButton jButton37;
     private javax.swing.JButton jButton38;
     private javax.swing.JButton jButton4;
@@ -2261,7 +2213,6 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JLabel jLabel29;
     private javax.swing.JLabel jLabel3;
     private javax.swing.JLabel jLabel30;
-    private javax.swing.JLabel jLabel31;
     private javax.swing.JLabel jLabel32;
     private javax.swing.JLabel jLabel33;
     private javax.swing.JLabel jLabel34;
@@ -2351,7 +2302,6 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JTextField jTextField26;
     private javax.swing.JTextField jTextField27;
     private javax.swing.JTextField jTextField28;
-    private javax.swing.JTextField jTextField29;
     private javax.swing.JTextField jTextField30;
     private javax.swing.JTextField jTextField31;
     private javax.swing.JTextField jTextField32;

--- a/src/com/sfc/sf2/battle/gui/MainEditor.java
+++ b/src/com/sfc/sf2/battle/gui/MainEditor.java
@@ -1139,7 +1139,7 @@ public class MainEditor extends javax.swing.JFrame {
 
             jLabel27.setText("Spriteset :");
 
-            jTextField25.setText(".\\entries\\battle01\\spriteset.bin");
+            jTextField25.setText(".\\spritesets\\spriteset01.asm");
             jTextField25.addActionListener(new java.awt.event.ActionListener() {
                 public void actionPerformed(java.awt.event.ActionEvent evt) {
                     jTextField25ActionPerformed(evt);
@@ -1224,7 +1224,7 @@ public class MainEditor extends javax.swing.JFrame {
                 .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel3Layout.createSequentialGroup()
                     .addComponent(jLabel23)
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                    .addComponent(jTextField21, javax.swing.GroupLayout.DEFAULT_SIZE, 86, Short.MAX_VALUE)
+                    .addComponent(jTextField21, javax.swing.GroupLayout.PREFERRED_SIZE, 1, Short.MAX_VALUE)
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                     .addComponent(jButton28))
                 .addGroup(jPanel3Layout.createSequentialGroup()
@@ -1248,7 +1248,7 @@ public class MainEditor extends javax.swing.JFrame {
                 .addGroup(jPanel3Layout.createSequentialGroup()
                     .addComponent(jLabel25)
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                    .addComponent(jTextField23, javax.swing.GroupLayout.DEFAULT_SIZE, 70, Short.MAX_VALUE)
+                    .addComponent(jTextField23)
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                     .addComponent(jButton30))
                 .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel3Layout.createSequentialGroup()
@@ -1489,7 +1489,7 @@ public class MainEditor extends javax.swing.JFrame {
             jPanel9.setLayout(jPanel9Layout);
             jPanel9Layout.setHorizontalGroup(
                 jPanel9Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addComponent(jTabbedPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 249, Short.MAX_VALUE)
+                .addComponent(jTabbedPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 249, Short.MAX_VALUE)
             );
             jPanel9Layout.setVerticalGroup(
                 jPanel9Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)

--- a/src/com/sfc/sf2/battle/io/DisassemblyManager.java
+++ b/src/com/sfc/sf2/battle/io/DisassemblyManager.java
@@ -361,12 +361,12 @@ public class DisassemblyManager {
             if(spritesetPath.endsWith(".asm")){
                 StringBuilder asm = new StringBuilder();
                 asm.append(header);
-                asm.append(produceSpriteSetBytesAsm(spriteset, enemyEnums));
+                asm.append(produceSpriteSetAsm(spriteset, enemyEnums));
                 Path spritesetFilepath = Paths.get(spritesetPath);
                 Files.write(spritesetFilepath, asm.toString().getBytes());
                 System.out.println(asm);
             }else{
-                byte[] spritesetBytes = produceSpriteSetBytesBin(spriteset, enemyEnums);
+                byte[] spritesetBytes = produceSpriteSetBin(spriteset, enemyEnums);
                 Path spritesetFilepath = Paths.get(spritesetPath);
                 Files.write(spritesetFilepath, spritesetBytes);
                 System.out.println(spritesetBytes.length + " bytes into " + spritesetFilepath);
@@ -379,7 +379,7 @@ public class DisassemblyManager {
         System.out.println("com.sfc.sf2.battle.io.DisassemblyManager.exportSpriteSet() - Disassembly exported.");         
     }
     
-    private static String produceSpriteSetBytesAsm(SpriteSet spriteset, EnemyEnums enemyEnums){
+    private static String produceSpriteSetAsm(SpriteSet spriteset, EnemyEnums enemyEnums){
                 
         Ally[] allies = spriteset.getAllies();
         Enemy[] enemies = spriteset.getEnemies();
@@ -389,18 +389,18 @@ public class DisassemblyManager {
         StringBuilder asm = new StringBuilder();
         
         //Sizes
-        asm.append("                ; # Allies");
+        asm.append("                ; # Allies\n");
         asm.append("                "+MACRO_DCB+" "+allies.length+"\n");
-        asm.append("                ; # Enemies");
+        asm.append("                ; # Enemies\n");
         asm.append("                "+MACRO_DCB+" "+enemies.length+"\n");
-        asm.append("                ; # AI Regions");
+        asm.append("                ; # AI Regions\n");
         asm.append("                "+MACRO_DCB+" "+aiRegions.length+"\n");
-        asm.append("                ; # AI Points");
+        asm.append("                ; # AI Points\n");
         asm.append("                "+MACRO_DCB+" "+aiPoints.length+"\n");
         asm.append("\n");
         
         //Allies
-        asm.append("                ; Allies");
+        asm.append("                ; Allies\n");
         for(int i=0;i<allies.length;i++){
             Ally ally = allies[i];
             asm.append("                "+MACRO_ALLIES+" "+ally.getIndex()+", "+ally.getX()+", "+ally.getY()+"\n");
@@ -410,7 +410,7 @@ public class DisassemblyManager {
         asm.append("\n");
         
         //Enemies
-        asm.append("                ; Enemies");
+        asm.append("                ; Enemies\n");
         for(int i=0;i<enemies.length;i++){
             Enemy enemy = enemies[i];
             
@@ -424,12 +424,12 @@ public class DisassemblyManager {
             asm.append("                "+MACRO_ENEMIES+" "+name+", "+enemy.getX()+", "+enemy.getY()+"\n");
             asm.append("                "+MACRO_ENEMY_LINE2+" "+command+", "+item+"\n");
             asm.append("                "+MACRO_ENEMY_LINE3+" "+moveOrder1+", "+enemy.getTriggerRegion1()+", "+moveOrder2+", "
-                    +enemy.getTriggerRegion2()+", "+enemy.getByte10()+", "+spawnParams+"\n");
+                                         +enemy.getTriggerRegion2()+", "+enemy.getByte10()+", "+spawnParams+"\n");
         }
         asm.append("\n");
         
         //Regions
-        asm.append("                ; AI Regions");
+        asm.append("                ; AI Regions\n");
         for(int i=0;i<aiRegions.length;i++){
             AIRegion region = aiRegions[i];
             asm.append("                "+MACRO_DCB+" "+region.getType()+"\n");
@@ -444,7 +444,7 @@ public class DisassemblyManager {
         asm.append("\n");
         
         //AI Points
-        asm.append("                ; AI Points");
+        asm.append("                ; AI Points\n");
         for(int i=0;i<aiPoints.length;i++){
             AIPoint point = aiPoints[i];
             asm.append("                "+MACRO_DCB+" "+point.getX()+", "+point.getY()+"\n");
@@ -455,7 +455,7 @@ public class DisassemblyManager {
     }
     
     //Lagacy? Do spritesets need binary format anymore?
-    private static byte[] produceSpriteSetBytesBin(SpriteSet spriteset, EnemyEnums enemyEnums){
+    private static byte[] produceSpriteSetBin(SpriteSet spriteset, EnemyEnums enemyEnums){
         Ally[] allies = spriteset.getAllies();
         Enemy[] enemies = spriteset.getEnemies();
         AIRegion[] aiRegions = spriteset.getAiRegions();

--- a/src/com/sfc/sf2/battle/io/DisassemblyManager.java
+++ b/src/com/sfc/sf2/battle/io/DisassemblyManager.java
@@ -176,7 +176,6 @@ public class DisassemblyManager {
                     if (scan.hasNext()){
                         line = scan.nextLine();
                         
-                        //TODO new datatype
                         params = line.trim().substring(MACRO_ENEMY_LINE2.length()).trim().split(",");
                         aiCommand = EnemyEnums.toEnumString(params[0].trim(), enemyEnums.getCommandSets());
                         item = EnemyEnums.stringToItemString(params[1].trim(), enemyEnums.getItems());
@@ -186,7 +185,6 @@ public class DisassemblyManager {
                     if (scan.hasNext()){
                         line = scan.nextLine();
                         
-                        //TODO new datatype
                         params = line.trim().substring(MACRO_ENEMY_LINE3.length()).trim().split(",");
                         moveOrder1 = EnemyEnums.stringToAiOrderString(params[0].trim(), enemyEnums.getOrders());
                         region1 = Integer.parseInt(params[1].trim());

--- a/src/com/sfc/sf2/battle/io/DisassemblyManager.java
+++ b/src/com/sfc/sf2/battle/io/DisassemblyManager.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
@@ -524,7 +525,7 @@ public class DisassemblyManager {
         List<EnemyData> enemyDataList = new ArrayList(enemyEnums.getEnemies().size());
             
         try {
-            Map<String, Integer> enemies = enemyEnums.getEnemies();
+            LinkedHashMap<String, Integer> enemies = enemyEnums.getEnemies();
             for (Map.Entry<String, Integer> entry : enemies.entrySet()) {
                 EnemyData enemy = new EnemyData();
                 enemy.setName(entry.getKey());
@@ -585,11 +586,11 @@ public class DisassemblyManager {
     
     public static EnemyEnums importEnemyEnums(String mapspriteEnumPath){
         System.out.println("com.sfc.sf2.battle.io.DisassemblyManager.importEnemyEnums() - Importing disassembly ...");
-        Map<String, Integer> enemies = new HashMap<>();
-        Map<String, Integer> items = new HashMap<>();
-        Map<String, Integer> aiCommandSets = new HashMap<>();
-        Map<String, Integer> aiOrders = new HashMap<>();
-        Map<String, Integer> spawnParams = new HashMap<>();
+        LinkedHashMap<String, Integer> enemies = new LinkedHashMap<>();
+        LinkedHashMap<String, Integer> items = new LinkedHashMap<>();
+        LinkedHashMap<String, Integer> aiCommandSets = new LinkedHashMap<>();
+        LinkedHashMap<String, Integer> aiOrders = new LinkedHashMap<>();
+        LinkedHashMap<String, Integer> spawnParams = new LinkedHashMap<>();
             
         EnemyEnums enemyEnums = new EnemyEnums();
         int itemEquippedValue = 0;

--- a/src/com/sfc/sf2/battle/io/DisassemblyManager.java
+++ b/src/com/sfc/sf2/battle/io/DisassemblyManager.java
@@ -219,7 +219,17 @@ public class DisassemblyManager {
                         while(!line.startsWith("; enum")){
                             if(line.startsWith("MAPSPRITE")){
                                 String key = line.substring(0,line.indexOf(":"));
-                                Integer value = Integer.valueOf(line.substring(line.indexOf("$")+1).trim(), 16);
+                                Integer value = line.indexOf("$")+1;
+                                if (value <= 0){
+                                    value = line.indexOf("equ")+4;
+                                }
+                                Integer comment = line.indexOf(";");
+                                if (comment == -1){
+                                    value = Integer.valueOf(line.substring(value).trim(), 16);
+                                }
+                                else{
+                                    value = Integer.valueOf(line.substring(value, comment).trim(), 16);
+                                }
                                 mapspriteEnum.put(key, value);
                             }
                             line = enumScan.nextLine();

--- a/src/com/sfc/sf2/battle/io/DisassemblyManager.java
+++ b/src/com/sfc/sf2/battle/io/DisassemblyManager.java
@@ -80,36 +80,36 @@ public class DisassemblyManager {
                         
                         AIRegion newAIRegion = new AIRegion();
                         //Line 1
-                        newAIRegion.setType(Integer.valueOf(params[0].trim()));
+                        newAIRegion.setType(Integer.parseInt(params[0].trim()));
                         //Line 2 (Ignore)
                         if (scan.hasNext()){ scan.nextLine(); }
                         //Line 3
                         if (scan.hasNext()){
                             line = scan.nextLine();
                             params = line.trim().substring(MACRO_DCB.length()).trim().split(",");
-                            newAIRegion.setX1(Integer.valueOf(params[0].trim()));
-                            newAIRegion.setY1(Integer.valueOf(params[1].trim()));
+                            newAIRegion.setX1(Integer.parseInt(params[0].trim()));
+                            newAIRegion.setY1(Integer.parseInt(params[1].trim()));
                         }
                         //Line 4
                         if (scan.hasNext()){
                             line = scan.nextLine();
                             params = line.trim().substring(MACRO_DCB.length()).trim().split(",");
-                            newAIRegion.setX2(Integer.valueOf(params[0].trim()));
-                            newAIRegion.setY2(Integer.valueOf(params[1].trim()));
+                            newAIRegion.setX2(Integer.parseInt(params[0].trim()));
+                            newAIRegion.setY2(Integer.parseInt(params[1].trim()));
                         }
                         //Line 5
                         if (scan.hasNext()){
                             line = scan.nextLine();
                             params = line.trim().substring(MACRO_DCB.length()).trim().split(",");
-                            newAIRegion.setX3(Integer.valueOf(params[0].trim()));
-                            newAIRegion.setY3(Integer.valueOf(params[1].trim()));
+                            newAIRegion.setX3(Integer.parseInt(params[0].trim()));
+                            newAIRegion.setY3(Integer.parseInt(params[1].trim()));
                         }
                         //Line 6
                         if (scan.hasNext()){
                             line = scan.nextLine();
                             params = line.trim().substring(MACRO_DCB.length()).trim().split(",");
-                            newAIRegion.setX4(Integer.valueOf(params[0].trim()));
-                            newAIRegion.setY4(Integer.valueOf(params[1].trim()));
+                            newAIRegion.setX4(Integer.parseInt(params[0].trim()));
+                            newAIRegion.setY4(Integer.parseInt(params[1].trim()));
                         }
                         //Line 7 & 8 (Ignore)
                         if (scan.hasNext()){ scan.nextLine(); }
@@ -122,8 +122,8 @@ public class DisassemblyManager {
                         String[] params = line.trim().substring(MACRO_DCB.length()).trim().split(",");
                         if (params.length == 2){
                             AIPoint newPoint = new AIPoint();
-                            newPoint.setX(Integer.valueOf(params[0].trim()));
-                            newPoint.setY(Integer.valueOf(params[1].trim()));
+                            newPoint.setX(Integer.parseInt(params[0].trim()));
+                            newPoint.setY(Integer.parseInt(params[1].trim()));
                             aiPointList.add(newPoint);
                         }
                     }
@@ -139,9 +139,9 @@ public class DisassemblyManager {
                     */
                     
                     String[] params = line.trim().substring(MACRO_ALLIES.length()).trim().split(",");
-                    int index = Integer.valueOf(params[0].trim());
-                    int x = Integer.valueOf(params[1].trim());
-                    int y = Integer.valueOf(params[2].trim());
+                    int index = Integer.parseInt(params[0].trim());
+                    int x = Integer.parseInt(params[1].trim());
+                    int y = Integer.parseInt(params[2].trim());
                     Ally newAlly = new Ally();
                     newAlly.setIndex(index);
                     newAlly.setX(x);
@@ -168,12 +168,12 @@ public class DisassemblyManager {
                                           
                     //Line 1
                     name = params[0].trim();
-                    x = Integer.valueOf(params[1].trim());
-                    y = Integer.valueOf(params[2].trim());
+                    x = Integer.parseInt(params[1].trim());
+                    y = Integer.parseInt(params[2].trim());
                     
                     //Line 2
                     if (scan.hasNext()){
-                        scan.nextLine();
+                        line = scan.nextLine();
                         
                         //TODO new datatype
                         params = line.trim().substring("MACRO_ENEMY_LINE2".length()).trim().split(",");
@@ -183,15 +183,15 @@ public class DisassemblyManager {
                           
                     //Line 3
                     if (scan.hasNext()){
-                        scan.nextLine();
+                        line = scan.nextLine();
                         
                         //TODO new datatype
                         params = line.trim().substring("MACRO_ENEMY_LINE3".length()).trim().split(",");
                         moveOrder1 = EnemyEnums.stringToAiOrderString(params[0].trim(), enemyEnums.getOrders());
-                        region1 = Integer.valueOf(params[1].trim());
+                        region1 = Integer.parseInt(params[1].trim());
                         moveOrder2 = EnemyEnums.stringToAiOrderString(params[2].trim(), enemyEnums.getOrders());
-                        region2 = Integer.valueOf(params[3].trim());
-                        unknownParam = Integer.valueOf(params[4].trim());
+                        region2 = Integer.parseInt(params[3].trim());
+                        unknownParam = Integer.parseInt(params[4].trim());
                         spawnParams = EnemyEnums.toEnumString(params[5].trim(), enemyEnums.getSpawnParams());
                     }
                     
@@ -290,19 +290,19 @@ public class DisassemblyManager {
             for(int i=0;i<enemiesNumber;i++){
                 Enemy newEnemy = new Enemy();
                 
-                Integer id = Integer.valueOf(data[4+alliesNumber*12+i*12+0]&0xFF);
+                Integer id = data[4+alliesNumber*12+i*12+0]&0xFF;
                 if (enemyData[id] != null)
                     newEnemy.setEnemyData(enemyData[id]);                
                 newEnemy.setX(data[4+alliesNumber*12+i*12+1]);
                 newEnemy.setY(data[4+alliesNumber*12+i*12+2]);
-                newEnemy.setAi(enemyEnums.toEnumString(data[4+alliesNumber*12+i*12+3], enemyEnums.getCommandSets()));
+                newEnemy.setAi(EnemyEnums.toEnumString(data[4+alliesNumber*12+i*12+3], enemyEnums.getCommandSets()));
                 newEnemy.setItem(EnemyEnums.itemNumToString(getNextWord(data,4+alliesNumber*12+i*12+4), enemyEnums.getItems()));
                 newEnemy.setMoveOrder1(EnemyEnums.aiOrderNumToString(data[4+alliesNumber*12+i*12+6], enemyEnums.getOrders()));
                 newEnemy.setTriggerRegion1(data[4+alliesNumber*12+i*12+7]);
                 newEnemy.setMoveOrder2(EnemyEnums.aiOrderNumToString(data[4+alliesNumber*12+i*12+8], enemyEnums.getOrders()));
                 newEnemy.setTriggerRegion2(data[4+alliesNumber*12+i*12+9]);
                 newEnemy.setByte10(data[4+alliesNumber*12+i*12+10]);
-                newEnemy.setSpawnParams(enemyEnums.toEnumString(data[4+alliesNumber*12+i*12+11], enemyEnums.getSpawnParams()));
+                newEnemy.setSpawnParams(EnemyEnums.toEnumString(data[4+alliesNumber*12+i*12+11], enemyEnums.getSpawnParams()));
                 enemyList.add(newEnemy);
             }
             Enemy[] enemies = new Enemy[enemyList.size()];
@@ -389,23 +389,23 @@ public class DisassemblyManager {
         StringBuilder asm = new StringBuilder();
         
         //Sizes
-        asm.append("                ; # Allies\n");
-        asm.append("                "+MACRO_DCB+" "+allies.length+"\n");
-        asm.append("                ; # Enemies\n");
-        asm.append("                "+MACRO_DCB+" "+enemies.length+"\n");
-        asm.append("                ; # AI Regions\n");
-        asm.append("                "+MACRO_DCB+" "+aiRegions.length+"\n");
-        asm.append("                ; # AI Points\n");
-        asm.append("                "+MACRO_DCB+" "+aiPoints.length+"\n");
+        asm.append(String.format("                ; # Allies\n"));
+        asm.append(String.format("                %s %d\n", MACRO_DCB, allies.length));
+        asm.append(String.format("                ; # Enemies\n"));
+        asm.append(String.format("                %s %d\n", MACRO_DCB, enemies.length));
+        asm.append(String.format("                ; # AI Regions\n"));
+        asm.append(String.format("                %s %d\n", MACRO_DCB, aiRegions.length));
+        asm.append(String.format("                ; # AI Points\n"));
+        asm.append(String.format("                %s %d\n", MACRO_DCB, aiPoints.length));
         asm.append("\n");
         
         //Allies
         asm.append("                ; Allies\n");
         for(int i=0;i<allies.length;i++){
             Ally ally = allies[i];
-            asm.append("                "+MACRO_ALLIES+" "+ally.getIndex()+", "+ally.getX()+", "+ally.getY()+"\n");
-            asm.append("                "+MACRO_ENEMY_LINE2+" HEALER1, NOTHING\n");
-            asm.append("                "+MACRO_ENEMY_LINE3+" NONE, 0, NONE, 0, 0, STARTING\n");
+            asm.append(String.format("                %s %d, %d, %d\n", MACRO_ALLIES, ally.getIndex(), ally.getX(), ally.getY()));
+            asm.append(String.format("                %s HEALER1, NOTHING\n", MACRO_ENEMY_LINE2));
+            asm.append(String.format("                %s NONE, 15, NONE, 15, 0, STARTING\n\n", MACRO_ENEMY_LINE3));
         }
         asm.append("\n");
         
@@ -421,10 +421,10 @@ public class DisassemblyManager {
             String moveOrder2 = EnemyEnums.stringToAiOrderString(enemy.getMoveOrder2(), enemyEnums.getOrders());
             String spawnParams = EnemyEnums.toEnumString(enemy.getSpawnParams(), enemyEnums.getSpawnParams());
             
-            asm.append("                "+MACRO_ENEMIES+" "+name+", "+enemy.getX()+", "+enemy.getY()+"\n");
-            asm.append("                "+MACRO_ENEMY_LINE2+" "+command+", "+item+"\n");
-            asm.append("                "+MACRO_ENEMY_LINE3+" "+moveOrder1+", "+enemy.getTriggerRegion1()+", "+moveOrder2+", "
-                                         +enemy.getTriggerRegion2()+", "+enemy.getByte10()+", "+spawnParams+"\n");
+            asm.append(String.format("                "+MACRO_ENEMIES+" "+name+", "+enemy.getX()+", "+enemy.getY()+"\n"));
+            asm.append(String.format("                "+MACRO_ENEMY_LINE2+" "+command+", "+item+"\n"));
+            asm.append(String.format("                "+MACRO_ENEMY_LINE3+" "+moveOrder1+", "+enemy.getTriggerRegion1()+", "+moveOrder2+", "
+                                                        +enemy.getTriggerRegion2()+", "+enemy.getByte10()+", "+spawnParams+"\n\n"));
         }
         asm.append("\n");
         
@@ -432,14 +432,14 @@ public class DisassemblyManager {
         asm.append("                ; AI Regions\n");
         for(int i=0;i<aiRegions.length;i++){
             AIRegion region = aiRegions[i];
-            asm.append("                "+MACRO_DCB+" "+region.getType()+"\n");
-            asm.append("                "+MACRO_DCB+" 0\n");
-            asm.append("                "+MACRO_DCB+" "+region.getX1()+", "+region.getY1()+"\n");
-            asm.append("                "+MACRO_DCB+" "+region.getX2()+", "+region.getY2()+"\n");
-            asm.append("                "+MACRO_DCB+" "+region.getX3()+", "+region.getY3()+"\n");
-            asm.append("                "+MACRO_DCB+" "+region.getX4()+", "+region.getY4()+"\n");
-            asm.append("                "+MACRO_DCB+" 0\n");
-            asm.append("                "+MACRO_DCB+" 0\n");
+            asm.append(String.format("                %s %d\n", MACRO_DCB, region.getType()));
+            asm.append(String.format("                %s 0\n", MACRO_DCB));
+            asm.append(String.format("                %s %d, %d\n", MACRO_DCB, region.getX1(), region.getY1()));
+            asm.append(String.format("                %s %d, %d\n", MACRO_DCB, region.getX2(), region.getY2()));
+            asm.append(String.format("                %s %d, %d\n", MACRO_DCB, region.getX3(), region.getY3()));
+            asm.append(String.format("                %s %d, %d\n", MACRO_DCB, region.getX4(), region.getY4()));
+            asm.append(String.format("                %s 0\n", MACRO_DCB));
+            asm.append(String.format("                %s 0\n", MACRO_DCB));
         }
         asm.append("\n");
         
@@ -447,7 +447,7 @@ public class DisassemblyManager {
         asm.append("                ; AI Points\n");
         for(int i=0;i<aiPoints.length;i++){
             AIPoint point = aiPoints[i];
-            asm.append("                "+MACRO_DCB+" "+point.getX()+", "+point.getY()+"\n");
+            asm.append(String.format("                %s %d, %d\n", MACRO_DCB, point.getX(), point.getY()));
         }
         asm.append("\n");
         
@@ -546,7 +546,7 @@ public class DisassemblyManager {
                 }
                 
             }else{ 
-                Map<String, Integer> map = new HashMap<String, Integer>();
+                Map<String, Integer> map = new HashMap<>();
                 
                 File file = new File(filepath);
                 Scanner scan = new Scanner(file);
@@ -624,15 +624,16 @@ public class DisassemblyManager {
         Map<String, Integer> aiCommandSets = new HashMap<>();
         Map<String, Integer> aiOrders = new HashMap<>();
         Map<String, Integer> spawnParams = new HashMap<>();
+        
+        int itemEquippedValue = 0;
+        int itemNothingValue = 0;
             
         try {
             if(mapspriteEnumPath.endsWith(".bin")){
         
                 //TODO Handle .bin enums (is this necessary?)
                 
-            }else{ 
-                Map<String, Integer> map = new HashMap<String, Integer>();
-                
+            }else{                                
                 File file = new File(mapspriteEnumPath);
                 Scanner scan = new Scanner(file);
                 while(scan.hasNext()){
@@ -689,8 +690,22 @@ public class DisassemblyManager {
                             if(line.startsWith("ITEM_")){
                                 line = line.substring(line.indexOf("_")+1);
                                 String item = line.substring(0, line.indexOf(":"));
-                                int value = valueOf(line.substring(line.indexOf("equ")+4));
+                                int value = 0;
+                                if (item.equals("NOTHING"))
+                                    value = itemNothingValue;
+                                else if (item.equals("EQUIPPED"))
+                                    value = itemEquippedValue;
+                                else
+                                    value = valueOf(line.substring(line.indexOf("equ")+4));
                                 items.put(item, value);
+                            }
+                            else if (line.startsWith("item")){
+                                //Get the ITEM_NOTHING & ITEM
+                                //TODO .asm will store as string so the value doesn't matter. .bin will store value which will only support expanded item values
+                                if (line.startsWith("itemNothing"))
+                                    itemNothingValue = valueOf(line.substring(line.indexOf("=")+1));
+                                else if (line.startsWith("itemEquipped"))
+                                    itemEquippedValue = valueOf(line.substring(line.indexOf("=")+1));
                             }
                             else if (line.startsWith("; --")){
                                 break;
@@ -703,14 +718,19 @@ public class DisassemblyManager {
         } catch (IOException ex) {
             Logger.getLogger(DisassemblyManager.class.getName()).log(Level.SEVERE, null, ex);
         }
-        System.out.println("com.sfc.sf2.battle.io.DisassemblyManager.importEnemyEnums() - Disassembly imported.");
         
+        System.out.println("Items imported: " + items.size() + " entries.");
+        System.out.println("AI Commands imported: " + aiCommandSets.size() + " entries.");
+        System.out.println("AI Orders imported: " + aiOrders.size() + " entries.");
+        System.out.println("Spawn Params imported: " + spawnParams.size() + " entries.");
             
         EnemyEnums enemyEnums = new EnemyEnums();
         enemyEnums.setItems(items);
         enemyEnums.setCommandSets(aiCommandSets);
         enemyEnums.setOrders(aiOrders);
         enemyEnums.setSpawnParams(spawnParams);
+        System.out.println("com.sfc.sf2.battle.io.DisassemblyManager.importEnemyEnums() - Disassembly imported.");
+        
         return enemyEnums;
     }
     


### PR DESCRIPTION
Big update that makes the BattleEditor support the spritesets in .asm format, without removing the .bin functionality too.

## Features
- Can now import/export .asm spritesets (in DisassemblyManager)
    - Kept the .bin support (but default prioritised .asm)
- Importing Enemies, Item, AICommands, AIOrders, SpawnParams for SF2ENUMS as LinkedHashMaps in order to be able to parse text data & convert to/from binary (in EnemyEnums)
    - Needed a way to parse between strings (.asm) and bytes (.bin)
    - Not actual Enums (because they need to be defined at compile time)
    - TODO Support SF2ENUMS as bin??
- Added EnemyData construct as a way of storing enemy Name, ID, and Sprite
    - This might be a little heavy-handed but it gets the job done cleanly
- Was able to make the enemies panel more intuitive, using the imported text labels
- enemySpritesPath editor field was removed because the EnemyEnums made this redundant.
- Slightly better positioning of the 'missing sprite' numbers (in BattlePanel) - the green/red numbers

## Focus areas
- Default paths in editor updated to support current folder structure of SF2DISASM
- EnemyData may or may not be how you wish to handle enemy data
- EnemyEnums parsing is not the most optimised (searching SF2ENUMS twice).
- EnemyPropertiesTableModel was updated to use Object types (to handle Strings and Ints). Is there a cleaner way to handle this?
- Layout for the middle panel (coords, enemies, spritesheets, etc) could be cleaned up a little (default sizing)
- Added to MainEditor:  UpdateEnemyControls & OnEnemyDataChanged to support enabling the enemy controls.


_I needed the BattleEditor to work so I fixed it 😁_